### PR TITLE
Add a DSL for SD-JWT

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DecoyGen.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DecoyGen.kt
@@ -36,7 +36,8 @@ fun interface DecoyGen {
      * @return a series of decoy [HashedDisclosure]
      */
     fun gen(hashingAlgorithm: HashAlgorithm, numOfDecoys: Int): Collection<HashedDisclosure> {
-        return (1..numOfDecoys).map { gen(hashingAlgorithm) }
+        return if (numOfDecoys < 1) emptyList()
+        else (1..Random.nextInt(1, numOfDecoys)).map { gen(hashingAlgorithm) }
     }
 
     companion object {

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DisclosedClaimSet.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DisclosedClaimSet.kt
@@ -16,7 +16,10 @@
 package eu.europa.ec.eudi.sdjwt
 
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.json.*
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.putJsonArray
 import java.util.*
 
 /**
@@ -25,7 +28,7 @@ import java.util.*
  * @param disclosures the disclosures calculated
  * @param claimSet the JSON object that contains the hashed disclosures and possible plain claims
  */
-class DisclosedClaimSet(val disclosures: Set<Disclosure>, val claimSet: JsonObject) {
+class DisclosedClaimSet private constructor(val disclosures: Set<Disclosure>, val claimSet: JsonObject) {
     operator fun component1(): Set<Disclosure> = disclosures
     operator fun component2(): JsonObject = claimSet
 
@@ -34,7 +37,7 @@ class DisclosedClaimSet(val disclosures: Set<Disclosure>, val claimSet: JsonObje
         /**
          * An empty claim set with no disclosures
          */
-        val Empty: DisclosedClaimSet = plain(JsonObject(emptyMap()))
+        private val Empty: DisclosedClaimSet = plain(JsonObject(emptyMap()))
 
         /**
          * Creates a [DisclosedClaimSet] with no disclosures
@@ -43,80 +46,70 @@ class DisclosedClaimSet(val disclosures: Set<Disclosure>, val claimSet: JsonObje
          *
          * @return a [DisclosedClaimSet] with no disclosures
          */
-        fun plain(plainClaims: JsonObject = JsonObject(mapOf())): DisclosedClaimSet =
+        private fun plain(plainClaims: JsonObject = JsonObject(mapOf())): DisclosedClaimSet =
             DisclosedClaimSet(emptySet(), plainClaims)
+
+        @OptIn(ExperimentalSerializationApi::class)
+        private fun flat(
+            hashAlgorithm: HashAlgorithm,
+            saltProvider: SaltProvider,
+            numOfDecoys: Int,
+            claims: Set<Claim>,
+        ): DisclosedClaimSet =
+            DisclosuresAndHashes.make(
+                hashAlgorithm,
+                saltProvider,
+                JsonObject(claims.toMap()),
+                numOfDecoys,
+            ).run {
+                if (hashes.isEmpty()) Empty
+                else
+                    DisclosedClaimSet(
+                        disclosures,
+                        buildJsonObject {
+                            putJsonArray("_sd") { addAll(hashes.map { it.toJson() }) }
+                        },
+                    )
+            }
 
         /**
          * @param hashAlgorithm the algorithm to be used for hashing disclosures
          * @param saltProvider provides [Salt] for the creation of [disclosures][Disclosure]
-         * @param plainClaims Claims that are not selectively disclosable are included  in plaintext
-         * @param claimsToBeDisclosed claims to be selectively disclosed
+         * @param dsl The SD-JWT structure
          * @param numOfDecoys the number of decoys
          * @return
          */
-        fun flat(
-            hashAlgorithm: HashAlgorithm,
+        fun disclose(
+            hashAlgorithm: HashAlgorithm = HashAlgorithm.SHA3_256,
             saltProvider: SaltProvider = SaltProvider.Default,
-            plainClaims: JsonObject = JsonObject(emptyMap()),
-            claimsToBeDisclosed: JsonObject,
             numOfDecoys: Int = 0,
+            dsl: SdJwtDsl,
         ): Result<DisclosedClaimSet> = runCatching {
-            val disclosuresAndHashes =
-                DisclosuresAndHashes.make(hashAlgorithm, saltProvider, claimsToBeDisclosed, numOfDecoys)
-            val disclosedClaims = disclosuresAndHashes.toFlatDisclosedClaimSet(true)
-
-            plain(plainClaims) + disclosedClaims
-        }
-
-        /**
-         *
-         * Method accepts one or more [claimsToBeDisclosed], calculates the related disclosures
-         * and returns the list of disclosures and a new [JsonObject] which contains the hashed disclosures (instead
-         * of the claims)
-         *
-         * @param hashAlgorithm the algorithm to be used for hashing disclosures
-         * @param saltProvider provides [Salt] for the creation of [disclosures][Disclosure]
-         */
-        fun structured(
-            hashAlgorithm: HashAlgorithm,
-            saltProvider: SaltProvider = SaltProvider.Default,
-            plainClaims: JsonObject = JsonObject(emptyMap()),
-            claimsToBeDisclosed: JsonObject,
-            numOfDecoys: Int = 0,
-            includeHashAlgClaim: Boolean = true,
-        ): Result<DisclosedClaimSet> = runCatching {
-            fun structuredDisclosed(claimName: String, claimValue: JsonElement): DisclosedClaimSet {
-                val disclosuresAndHashes = when (claimValue) {
-                    is JsonObject -> claimValue.map { subClaim ->
-                        DisclosuresAndHashes.make(
-                            hashAlgorithm,
-                            saltProvider,
-                            JsonObject(mapOf(subClaim.toPair())),
-                            numOfDecoys,
-                        )
-                    }.fold(DisclosuresAndHashes.empty(hashAlgorithm), DisclosuresAndHashes::combine)
-
-                    else -> DisclosuresAndHashes.make(
-                        hashAlgorithm,
-                        saltProvider,
-                        JsonObject(mapOf(claimName to claimValue)),
-                        numOfDecoys,
-                    )
+            fun doDisclose(x: SdJwtDsl): DisclosedClaimSet = when (x) {
+                is SdJwtDsl.Plain -> plain(JsonObject(x.claim))
+                is SdJwtDsl.Flat -> flat(hashAlgorithm, saltProvider, numOfDecoys, x.claims)
+                is SdJwtDsl.Structured -> doDisclose(x.flatSubClaims).let { fs ->
+                    val combined = JsonObject(fs.claimSet + x.plainSubClaims.claim)
+                    DisclosedClaimSet(fs.disclosures, JsonObject(mapOf(x.claimName to combined)))
                 }
-                return disclosuresAndHashes.toStructureDisclosedClaimSet(claimName)
+
+                is SdJwtDsl.TopLevel -> {
+                    val ps = doDisclose(x.plain)
+                    val fs = x.flat?.let { doDisclose(it) } ?: Empty
+                    val ss = x.structured.map { doDisclose(it) }
+                    fun hashClaim() = doDisclose(
+                        SdJwtDsl.Plain(mapOf(hashAlgorithm.toClaim())),
+                    )
+
+                    val disclosed = ss + fs
+                    val all = disclosed + ps
+                    val initial =
+                        if (disclosed.any { it.claimSet.isNotEmpty() }) hashClaim()
+                        else Empty
+                    all.fold(initial, DisclosedClaimSet::combine)
+                }
             }
-
-            val initial = plain(
-                JsonObject(
-                    plainClaims +
-                            if (claimsToBeDisclosed.isNotEmpty() && includeHashAlgClaim) mapOf(hashAlgorithm.toClaim())
-                            else emptyMap(),
-                ),
-            )
-
-            claimsToBeDisclosed
-                .map { (claimName, claimValue) -> structuredDisclosed(claimName, claimValue) }
-                .fold(initial, DisclosedClaimSet::combine)
+            doDisclose(dsl)
         }
 
         /**
@@ -125,7 +118,7 @@ class DisclosedClaimSet(val disclosures: Set<Disclosure>, val claimSet: JsonObje
          * @return a new [DisclosedClaimSet] which contains the combined set of [DisclosedClaimSet.claimSet] and the
          * combined [DisclosedClaimSet.claimSet]
          */
-        fun combine(a: DisclosedClaimSet, b: DisclosedClaimSet): DisclosedClaimSet {
+        private fun combine(a: DisclosedClaimSet, b: DisclosedClaimSet): DisclosedClaimSet {
             assertNoCommonElements(a.disclosures, b.disclosures) {
                 "Cannot combine DisclosedClaimSet with common disclosures"
             }
@@ -140,9 +133,6 @@ class DisclosedClaimSet(val disclosures: Set<Disclosure>, val claimSet: JsonObje
         }
     }
 }
-
-operator fun DisclosedClaimSet.plus(that: DisclosedClaimSet): DisclosedClaimSet =
-    DisclosedClaimSet.combine(this, that)
 
 /**
  * A helper class for implementing flat disclosure
@@ -172,12 +162,6 @@ private class DisclosuresAndHashes private constructor(
     }
 
     companion object {
-
-        /**
-         * Creates an [DisclosuresAndHashes] with no disclosures or hashes
-         */
-        fun empty(hashAlgorithm: HashAlgorithm): DisclosuresAndHashes =
-            DisclosuresAndHashes(emptySet(), emptySet(), hashAlgorithm)
 
         fun decoys(
             hashAlgorithm: HashAlgorithm,
@@ -243,102 +227,11 @@ private class DisclosuresAndHashes private constructor(
         fun make(
             hashAlgorithm: HashAlgorithm,
             saltProvider: SaltProvider,
-            claimToBeDisclosed: Claim
+            claimToBeDisclosed: Claim,
         ): DisclosuresAndHashes {
             val d = Disclosure.encode(saltProvider, claimToBeDisclosed).getOrThrow()
             val h = HashedDisclosure.create(hashAlgorithm, d).getOrThrow()
             return DisclosuresAndHashes(setOf(d), setOf(h), hashAlgorithm)
-        }
-    }
-}
-
-/**
- * Creates a [DisclosedClaimSet] from a [DisclosuresAndHashes] where
- * the hashes are embedded tp the claim set with flat disclosure.
- *
- * @param includeHashAlgClaim whether to include the _sd_alg claim
- * @return the  [JsonObject] that contains the _sd claim and optionally the _sd_alg claim together with the
- * set of [Disclosure]
- */
-@OptIn(ExperimentalSerializationApi::class)
-private fun DisclosuresAndHashes.toFlatDisclosedClaimSet(includeHashAlgClaim: Boolean): DisclosedClaimSet {
-    return if (hashes.isNotEmpty())
-        DisclosedClaimSet(
-            disclosures,
-            buildJsonObject {
-                if (includeHashAlgClaim) put("_sd_alg", hashAlgorithm.toJson())
-                putJsonArray("_sd") { addAll(hashes.map { it.toJson() }) }
-            },
-        )
-    else DisclosedClaimSet.Empty
-}
-
-/**
- * Creates a [DisclosedClaimSet] from a [DisclosuresAndHashes] where
- * the hashes are embedded tp the claim set with structure disclosure.
- *
- * @param claimName the name of the claim
- * @return a  [JsonObject] that contains the _sd claim nested under the given [claimName] with the
- *  set of [Disclosure]
- */
-private fun DisclosuresAndHashes.toStructureDisclosedClaimSet(claimName: String): DisclosedClaimSet {
-    val json = buildJsonObject {
-        put(claimName, toFlatDisclosedClaimSet(false).claimSet)
-    }
-    return DisclosedClaimSet(disclosures, json)
-}
-
-object DisclosureOps {
-
-    private data class InterimDisclosedJsonObject(
-        val disclosures: List<Disclosure>,
-        val hashedDisclosures: List<HashedDisclosure>,
-        val json: JsonObject,
-    )
-
-    private fun structureDisclose(
-        hashAlgorithm: HashAlgorithm,
-        saltProvider: SaltProvider,
-        jsonToBeDisclosed: JsonObject,
-    ): Result<InterimDisclosedJsonObject> = runCatching {
-        val resultJson = mutableMapOf<String, JsonElement>()
-        val resultDs = mutableListOf<Disclosure>()
-        val resultHds = mutableListOf<HashedDisclosure>()
-
-        fun discloseAttribute(name: String, json: JsonElement) {
-            when (json) {
-                is JsonObject -> {
-                    val (ds, _, dJson) = structureDisclose(hashAlgorithm, saltProvider, json).getOrThrow()
-                    resultJson[name] = dJson
-                    resultDs.addAll(ds)
-                }
-
-                else -> {
-                    val d = Disclosure.encode(saltProvider, name to json).getOrThrow()
-                    val hd = HashedDisclosure.create(hashAlgorithm, d).getOrThrow()
-                    resultJson.addHashedDisclosuresClaim(setOf(hd))
-                    resultDs.add(d)
-                    resultHds.add(hd)
-                }
-            }
-        }
-
-        for ((name, json) in jsonToBeDisclosed) {
-            discloseAttribute(name, json)
-        }
-
-        InterimDisclosedJsonObject(resultDs, resultHds, JsonObject(resultJson))
-    }
-
-    //
-    // Helper methods for JSON
-    //
-
-    private fun MutableMap<String, JsonElement>.addHashedDisclosuresClaim(hds: Collection<HashedDisclosure>) {
-        if (hds.isNotEmpty()) {
-            val existingSds = this["_sd"]?.jsonArray ?: JsonArray(emptyList())
-            this["_sd"] =
-                JsonArray((existingSds + hds.map { it.toJson() }).shuffled())
         }
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtDsl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtDsl.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+sealed interface SdJwtDsl {
+
+    data class Plain(val claim: Map<String, JsonElement>) : SdJwtDsl
+    data class Flat(val claims: Set<Claim>) : SdJwtDsl
+    data class Structured(
+        val claimName: String,
+        val plainSubClaims: Plain = Empty,
+        val flatSubClaims: Flat,
+    ) : SdJwtDsl
+
+    data class TopLevel(
+        val plain: Plain = Empty,
+        val flat: Flat? = null,
+        val structured: Set<Structured> = emptySet(),
+    ) : SdJwtDsl
+
+    companion object {
+        val Empty: Plain = Plain(emptyMap())
+
+        fun plain(claim: Map<String, JsonElement>): Plain = Plain(claim)
+        fun flat(claims: Set<Claim>): Flat = Flat(claims)
+        fun flat(claims: Map<String, JsonElement>): Flat = Flat(claims.asSetOfClaims())
+        fun structured(
+            claimName: String,
+            plainSubClaims: Map<String, JsonElement>,
+            flatSubClaims: Map<String, JsonElement>,
+        ): Structured =
+            Structured(claimName, plain(plainSubClaims), flat(flatSubClaims))
+
+        fun structured(
+            claimName: String,
+            subClaims: Map<String, JsonElement>,
+            plainClaimsFilter: (Claim) -> Boolean,
+        ): Structured {
+            val plainSubClaims = subClaims.filter { plainClaimsFilter(it.toPair()) }
+            val subClaimsToBeDisclosed = subClaims - plainSubClaims.keys
+            return structured(claimName, plainSubClaims, subClaimsToBeDisclosed)
+        }
+
+        fun allFlat(plain: Map<String, JsonElement> = emptyMap(), flat: Map<String, JsonElement>): TopLevel =
+            TopLevel(plain(plain), flat(flat), emptySet())
+
+        private fun Map<String, JsonElement>.asSetOfClaims(): Set<Claim> = entries.map { it.toPair() }.toSet()
+    }
+}
+
+class SdJwtBuilder
+    @PublishedApi
+    internal constructor() {
+        val plain: MutableMap<String, JsonElement> = mutableMapOf()
+        val flat: MutableMap<String, JsonElement> = mutableMapOf()
+        val structured: MutableSet<SdJwtDsl.Structured> = mutableSetOf()
+
+        fun plain(builderAction: JsonObjectBuilder.() -> Unit) {
+            plain(buildJsonObject(builderAction))
+        }
+
+        fun flat(builderAction: JsonObjectBuilder.() -> Unit) {
+            flat(buildJsonObject(builderAction))
+        }
+
+        fun plain(c: Map<String, JsonElement>) {
+            plain.putAll(c)
+        }
+
+        fun flat(c: Claim) {
+            flat[c.name()] = c.value()
+        }
+
+        fun flat(c: Map<String, JsonElement>) {
+            flat.putAll(c)
+        }
+
+        fun structured(claimName: String, builderAction: StructuredBuilder.() -> Unit) {
+            structured.add(buildStructured(claimName, builderAction))
+        }
+
+        fun structured(claimName: String, subClaimsToBeDisclosed: Map<String, JsonElement>) {
+            structured.add(
+                SdJwtDsl.structured(
+                    claimName = claimName,
+                    plainSubClaims = emptyMap(),
+                    flatSubClaims = subClaimsToBeDisclosed,
+                ),
+            )
+        }
+
+        fun Pair<String, Map<String, JsonElement>>.structured() {
+            val (claimName, claimValue) = this
+            structured(claimName, claimValue)
+        }
+
+        fun structured(claimName: String, subClaims: Map<String, JsonElement>, plaintFilter: (Claim) -> Boolean) {
+            val plainSubClaims = subClaims.filter { plaintFilter(it.toPair()) }
+            val subClaimsToBeDisclosed = subClaims - plainSubClaims.keys
+            structured(claimName) {
+                if (plainSubClaims.isNotEmpty()) plain(plainSubClaims)
+                if (subClaimsToBeDisclosed.isNotEmpty()) flat(subClaimsToBeDisclosed)
+            }
+        }
+
+        fun build(): SdJwtDsl {
+            return SdJwtDsl.TopLevel(
+                plain = SdJwtDsl.Plain(JsonObject(plain)),
+                flat = if (flat.isEmpty()) null else SdJwtDsl.Flat(flat.entries.map { it.toPair() }.toSet()),
+                structured = structured,
+            )
+        }
+    }
+
+class StructuredBuilder
+    @PublishedApi
+    internal constructor() {
+        val plain: MutableMap<String, JsonElement> = mutableMapOf()
+        val flat: MutableMap<String, JsonElement> = mutableMapOf()
+
+        fun plain(builderAction: JsonObjectBuilder.() -> Unit) {
+            plain(buildJsonObject(builderAction))
+        }
+
+        fun flat(builderAction: JsonObjectBuilder.() -> Unit) {
+            flat(buildJsonObject(builderAction))
+        }
+
+        fun plain(c: JsonObject) {
+            plain.putAll(c)
+        }
+
+        fun flat(c: Claim) {
+            flat[c.name()] = c.value()
+        }
+
+        fun flat(c: Map<String, JsonElement>) {
+            flat.putAll(c)
+        }
+
+        fun build(claimName: String): SdJwtDsl.Structured {
+            return SdJwtDsl.Structured(
+                claimName = claimName,
+                plainSubClaims = SdJwtDsl.Plain(JsonObject(plain)),
+                flatSubClaims = SdJwtDsl.Flat(flat.entries.map { it.toPair() }.toSet()),
+
+            )
+        }
+    }
+
+@OptIn(ExperimentalContracts::class)
+inline fun sdJwt(builderAction: SdJwtBuilder.() -> Unit): SdJwtDsl {
+    contract { callsInPlace(builderAction, InvocationKind.EXACTLY_ONCE) }
+    val b = SdJwtBuilder()
+    b.builderAction()
+    return b.build()
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun buildStructured(claimName: String, builderAction: StructuredBuilder.() -> Unit): SdJwtDsl.Structured {
+    contract { callsInPlace(builderAction, InvocationKind.EXACTLY_ONCE) }
+    val b = StructuredBuilder()
+    b.builderAction()
+    return b.build(claimName)
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/BusinessExample.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/BusinessExample.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.*
+
+@Serializable
+data class Address(
+    val country: String,
+    @SerialName("street_address") val streetAddress: String,
+    val locality: String? = null,
+    val region: String,
+)
+
+@Serializable
+data class FooClaim(
+    @SerialName("sub") val subject: String,
+    @SerialName("iat") val issuedAt: Int,
+    @SerialName("home_address") val homeAddress: Address,
+    @SerialName("work_address") val workAddress: Address,
+)
+
+fun FooClaim.usingDsl(
+    hashAlgorithm: HashAlgorithm = HashAlgorithm.SHA3_256,
+    saltProvider: SaltProvider = SaltProvider.Default,
+): DisclosedClaimSet {
+    val jsonObject = json.encodeToJsonElement(this).jsonObject
+
+    // Here we define that home & work address are to be selectively disclosable
+    val plainClaims = JsonObject(jsonObject.filterNot { it.key == "home_address" || it.key == "work_address" })
+
+    fun Address.disclose(claimName: String, plainClaims: (Claim) -> Boolean = { false }) =
+        SdJwtDsl.structured(claimName, json.encodeToJsonElement<Address>(this).jsonObject, plainClaims)
+
+    val dsl = SdJwtDsl.TopLevel(
+        plain = SdJwtDsl.plain(plainClaims),
+        structured = setOf(
+            homeAddress.disclose("home_address"),
+            workAddress.disclose("work_address") { it.name() == "country" },
+        ),
+    )
+
+    return DisclosedClaimSet.disclose(hashAlgorithm, saltProvider, 2, dsl).getOrThrow()
+}
+
+fun FooClaim.usignBuilder(
+    hashAlgorithm: HashAlgorithm = HashAlgorithm.SHA3_256,
+    saltProvider: SaltProvider = SaltProvider.Default,
+): DisclosedClaimSet {
+    val jsonObject = json.encodeToJsonElement(this).jsonObject
+
+    // Here we define that home & work address are to be selectively disclosable
+    val plainClaims = JsonObject(jsonObject.filterNot { it.key == "home_address" || it.key == "work_address" })
+    val sdJwtDsl = sdJwt {
+        plain(plainClaims)
+        structured("work_address") {
+            jsonObject["work_address"]!!
+                .jsonObject
+                .forEach { x -> flat(x.toPair()) }
+        }
+
+        structured("home_address") {
+            flat {
+                put("country", "GR")
+                put("steet", "Markopoulo")
+            }
+        }
+    }
+    return DisclosedClaimSet.disclose(HashAlgorithm.SHA3_256, SaltProvider.Default, 0, sdJwtDsl).getOrThrow()
+}
+
+private val json = Json { prettyPrint = true }
+
+fun main() {
+    val homeAddress =
+        Address(country = "GR", streetAddress = "12 Foo Str", locality = null, region = "Attica")
+    val workAddress =
+        Address(country = "DE", streetAddress = "Schulstr. 12", locality = "Schulpforta", region = "Sachsen-Anhalt")
+    val fooClaim = FooClaim(
+        subject = "subject",
+        issuedAt = 10,
+        homeAddress = homeAddress,
+        workAddress = workAddress,
+    )
+
+    println("Advanced  example. Using DSL")
+    println("All attributes of both work and home address are selectively disclosable")
+    println("For work address country is plain")
+    fooClaim.usingDsl().also { it.print() }
+
+    println("Advanced  example. Using builder")
+
+    fooClaim.usignBuilder().also { it.print() }
+}
+
+fun DisclosedClaimSet.print() {
+    disclosures.forEach { println(it.claim()) }
+    claimSet.also { println(json.encodeToString(it)) }
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Sample.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Sample.kt
@@ -72,19 +72,23 @@ fun genRSAKeyPair(): RSAKey =
 fun main() {
     // this is the json we want to include in the JWT (not disclosed)
     val jwtVcJson: JsonObject = format.parseToJsonElement(jwtVcPayload).jsonObject
-    val (jwtClaims, vcClaim) = jwtVcJson.extractClaim("credentialSubject")
+    val jwtClaims = jwtVcJson.filterNot { it.key == "credentialSubject" }
+    val vcClaim = jwtVcJson["credentialSubject"]!!.jsonObject
 
     // Generate an RSA key pair
     val rsaJWK = genRSAKeyPair()
     val rsaPublicJWK = rsaJWK.toPublicJWK().also { println("\npublic key\n================\n$it") }
 
-    val sdJwt: CombinedIssuanceSdJwt = SdJwt.structureDiscloseAndEncode(
+    val sdJwt: CombinedIssuanceSdJwt = SdJwt.encode(
         signer = RSASSASigner(rsaJWK),
         signAlgorithm = JWSAlgorithm.RS256,
         hashAlgorithm = HashAlgorithm.SHA3_512,
-        plainClaims = jwtClaims,
-        claimsToBeDisclosed = vcClaim,
+        saltProvider = SaltProvider.Default,
         numOfDecoys = 0,
+        sdJwtDsl = sdJwt {
+            plain(jwtClaims)
+            structured("credentialSubject", vcClaim)
+        },
     ).getOrThrow()
 
     val (jwt, disclosures) = sdJwt.decompose().getOrThrow()


### PR DESCRIPTION
This PR defines a DSL (domain specific language) for expressing the structure of an SD-JWT

The DSL is implemented a sealed hierarchy (named `SdJwtDsl`) that defines the following members:

- Plain : for claims to be including in plain
- Flat: for claims to be selectively disclosed using flat disclosure
- Structured: for claims to be selectively disclosed using structured disclosure, and
- TopLevel: for aggregated the rest of the claims (plain, flat, structured) into sd-jwt

Also this PR implements a builder method that is compatible with Kotlinx Serialization builders 
```kotlin
val dsl = sdJwt {
   plain { 
       put("foo", "bar")
   }
   flat {
      put("c1", "d1")
   }
  flat {
     put("c2, 123)
  }

}
```