### PR TITLE
Add to the SD-JWT DSL support for including, in plain, JWT public r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,11 @@ import eu.europa.ec.eudi.sdjwt.*
 import kotlinx.serialization.json.*
 
 sdJwt {
-    plain { 
-        put("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
-        put("iss", "https://example.com/issuer")
-        put("iat", 1516239022)
-        put("exp", 1735689661)
-    }
+    sub("6c5c0a49-b589-431d-bae7-219122a9ec2c")
+    iss("https://example.com/issuer")
+    iat(1516239022)
+    exp(1735689661)
+
     flat {
         putJsonObject("address") {
             put("street_address", "Schulstr. 12")
@@ -99,12 +98,11 @@ to produce a SD-JWT which contains claim `sub` plain and `address` claim content
 
 ```kotlin
 sdJwt {
-    plain {
-        put("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
-        put("iss", "https://example.com/issuer")
-        put("iat", 1516239022)
-        put("exp", 1735689661)
-    }
+    sub("6c5c0a49-b589-431d-bae7-219122a9ec2c")
+    iss("https://example.com/issuer")
+    iat(1516239022)
+    exp(1735689661)
+
     structured("address") {
         flat {
             put("street_address", "Schulstr. 12")
@@ -163,12 +161,11 @@ Check [specification Option 3: SD-JWT with Recursive Disclosures](https://datatr
 
 ```kotlin
 sdJwt {
-    plain {
-        put("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
-        put("iss", "https://example.com/issuer")
-        put("iat", 1516239022)
-        put("exp", 1735689661)
-    }
+    sub("6c5c0a49-b589-431d-bae7-219122a9ec2c")
+    iss("https://example.com/issuer")
+    iat(1516239022)
+    exp(1735689661)
+
     recursively("address") {
         put("street_address", "Schulstr. 12")
         put("locality", "Schulpforta")
@@ -248,13 +245,14 @@ Description of the example in the [specification Example 2a: Handling Structured
   "birthdate": "1940-01-01"
 }
 ```
+
 ```kotlin
 sdJwt {
-    plain {
-        put("iss", "https://example.com/issuer")
-        put("iat", 1516239022)
-        put("exp", 1735689661)
-    }
+
+    iss("https://example.com/issuer")
+    iat(1516239022)
+    exp(1735689661)
+
     flat {
         put("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
         put("given_name", "太郎")

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtElementsBuilder.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtElementsBuilder.kt
@@ -15,9 +15,9 @@
  */
 package eu.europa.ec.eudi.sdjwt
 
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObjectBuilder
-import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.*
+import java.time.Instant
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -146,6 +146,91 @@ fun SdJwtElementsBuilder.recursively(
 ) {
     val element = SdJwtElement.RecursivelyDisclosed(claimName, buildJsonObject(builderAction))
     recursively(element)
+}
+
+/**
+ * Adds the JWT publicly registered JTI claim, in plain
+ */
+fun SdJwtElementsBuilder.jti(jti: String) {
+    plain(buildJsonObject { put("jti", jti) })
+}
+
+/**
+ * Adds the JWT publicly registered ISS claim (Issuer), in plain
+ */
+fun SdJwtElementsBuilder.iss(issuer: String) {
+    plain(buildJsonObject { put("iss", issuer) })
+}
+
+/**
+ * Adds the JWT publicly registered SUB claim (Subject), in plain
+ */
+fun SdJwtElementsBuilder.sub(subject: String) {
+    plain(buildJsonObject { put("sub", subject) })
+}
+
+/**
+ *  Adds the JWT publicly registered NBE claim (Not before), in plain
+ */
+fun SdJwtElementsBuilder.nbe(nbe: Instant) {
+    nbe(nbe.epochSecond)
+}
+
+/**
+ *  Adds the JWT publicly registered NBE claim (Not before), in plain
+ */
+fun SdJwtElementsBuilder.nbe(nbe: Long) {
+    plain(buildJsonObject { put("nbe", nbe) })
+}
+
+/**
+ *  Adds the JWT publicly registered IAT claim (Issued At), in plain
+ */
+fun SdJwtElementsBuilder.iat(iat: Instant) {
+    iat(iat.toEpochMilli())
+}
+
+/**
+ *  Adds the JWT publicly registered IAT claim (Issued At), in plain
+ */
+fun SdJwtElementsBuilder.iat(iat: Long) {
+    plain(buildJsonObject { put("iat", iat) })
+}
+
+/**
+ *  Adds the JWT publicly registered EXP claim (Expires), in plain
+ */
+fun SdJwtElementsBuilder.exp(exp: Instant) {
+    exp(exp.toEpochMilli())
+}
+
+/**
+ *  Adds the JWT publicly registered EXP claim (Expires), in plain
+ */
+fun SdJwtElementsBuilder.exp(exp: Long) {
+    plain(buildJsonObject { put("exp", exp) })
+}
+
+/**
+ * Adds the JWT publicly registered AUD claim (single Audience), in plain
+ */
+fun SdJwtElementsBuilder.aud(aud: String) {
+    plain(buildJsonObject { put("aud", aud) })
+}
+
+/**
+ * Adds the JWT publicly registered AUD claim (multiple Audience), in plain
+ */
+@OptIn(ExperimentalSerializationApi::class)
+fun SdJwtElementsBuilder.aud(aud: Collection<String>) {
+    when {
+        aud.size == 1 -> aud(aud.first())
+        aud.size > 1 -> plain {
+            buildJsonObject {
+                putJsonArray("aud") { buildJsonArray { addAll(aud) } }
+            }
+        }
+    }
 }
 
 @DslMarker

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SpecExamples.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SpecExamples.kt
@@ -30,12 +30,11 @@ class SpecExamples {
     @Test
     fun `Option 1 Flat SD-JWT`() = test("Option 1 Flat SD-JWT", 1) {
         sdJwt {
-            plain {
-                put("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
-                put("iss", "https://example.com/issuer")
-                put("iat", 1516239022)
-                put("exp", 1735689661)
-            }
+            sub("6c5c0a49-b589-431d-bae7-219122a9ec2c")
+            iss("https://example.com/issuer")
+            iat(1516239022)
+            exp(1735689661)
+
             flat {
                 putJsonObject("address") {
                     put("street_address", "Schulstr. 12")
@@ -50,12 +49,11 @@ class SpecExamples {
     @Test
     fun `Option 2 Structured SD-JWT`() = test("Option 2 Structured SD-JWT", 4) {
         sdJwt {
-            plain {
-                put("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
-                put("iss", "https://example.com/issuer")
-                put("iat", 1516239022)
-                put("exp", 1735689661)
-            }
+            sub("6c5c0a49-b589-431d-bae7-219122a9ec2c")
+            iss("https://example.com/issuer")
+            iat(1516239022)
+            exp(1735689661)
+
             structured("address") {
                 flat {
                     put("street_address", "Schulstr. 12")
@@ -70,12 +68,11 @@ class SpecExamples {
     @Test
     fun `Option 3 Recursively SD-JWT`() = test("Option 3 Recursively SD-JWT", 5) {
         sdJwt {
-            plain {
-                put("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
-                put("iss", "https://example.com/issuer")
-                put("iat", 1516239022)
-                put("exp", 1735689661)
-            }
+            sub("6c5c0a49-b589-431d-bae7-219122a9ec2c")
+            iss("https://example.com/issuer")
+            iat(1516239022)
+            exp(1735689661)
+
             recursively("address") {
                 put("street_address", "Schulstr. 12")
                 put("locality", "Schulpforta")
@@ -88,11 +85,10 @@ class SpecExamples {
     @Test
     fun `Example 2a`() = test("Example 2a", 7) {
         sdJwt {
-            plain {
-                put("iss", "https://example.com/issuer")
-                put("iat", 1516239022)
-                put("exp", 1735689661)
-            }
+            iss("https://example.com/issuer")
+            iat(1516239022)
+            exp(1735689661)
+
             flat {
                 put("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
                 put("given_name", "太郎")
@@ -113,11 +109,10 @@ class SpecExamples {
     @Test
     fun `Complex example`() = test("Complex example", 11) {
         sdJwt {
-            plain {
-                put("iss", "https://example.com/issuer")
-                put("iat", 1516239022)
-                put("exp", 1735689661)
-            }
+            iss("https://example.com/issuer")
+            iat(1516239022)
+            exp(1735689661)
+
             flat {
                 put("birth_middle_name", "Timotheus")
                 put("salutation", "Dr.")


### PR DESCRIPTION
This PR add support, for adding in SD-JWT, in plain, publicly registered JWT claims

```kotlin
sdJwt {
   plain { 
      put("sub", "some subject")
      put("iat", 123456) 
  }
}
```

The above is equivalent to 

```kotlin
sdJwt {
   sub("some subject")
   iat(123456)
}
```