### PR TITLE
Fix SonarCloud Workflow

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout project sources
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 #Shallow clones should be disabled for a better relevancy of SonarCloud analysis
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -26,7 +28,7 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Check secrets presence
+      - name: Check secrets presence & SonarCloud properties setup
         id: checksecrets
         shell: bash
         run: |
@@ -34,6 +36,7 @@ jobs:
             echo "secretspresent=NO" >> $GITHUB_OUTPUT
           else
             echo "secretspresent=YES" >> $GITHUB_OUTPUT
+            echo "PROJECTKEY=${{ github.repository_owner}}_$(echo ${{ github.repository }} | sed 's/.*\///')" >> $GITHUB_ENV
           fi
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN}}
@@ -42,8 +45,9 @@ jobs:
         uses: gradle/gradle-build-action@v2.5.1
         with:
           gradle-version: wrapper
-          arguments: build sonar --info --full-stacktrace -Dsonar.organization=${{ github.repository_owner }}
+          arguments: build sonar --info --full-stacktrace -Dsonar.organization=${{ github.repository_owner }} -Dsonar.projectKey=${{ env.PROJECTKEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           CI: true
+


### PR DESCRIPTION
This PR fixes collision in `sonar.projectKey` caused by the evaluation of the key from sonar gradle plugin.

With this PR, `sonar.projectKey` is evaluated by the github workflow that runs it