### PR TITLE
Add support for FlatNested disclosure - EUDI PID as SD-JWT

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Types.kt
@@ -82,9 +82,14 @@ enum class HashAlgorithm(val alias: String) {
 sealed interface SdJwtElement {
     data class Plain(val claims: Claims) : SdJwtElement
     data class FlatDisclosed(val claims: Claims) : SdJwtElement
-    data class StructuredDisclosed(val claimName: String, val elements: List<SdJwtElement>) : SdJwtElement
     data class RecursivelyDisclosed(val claimName: String, val claims: Claims) : SdJwtElement
-    data class Array(val claimName: String, val elements: List<SdArrayElement>) : SdJwtElement
+
+    sealed interface FlatNestable : SdJwtElement {
+        val claimName: String
+    }
+    data class StructuredDisclosed(override val claimName: String, val elements: List<SdJwtElement>) : FlatNestable
+    data class SelectivelyDisclosedArray(override val claimName: String, val elements: List<SdArrayElement>) : FlatNestable
+    data class FlatNested(val nested: FlatNestable) : SdJwtElement
 }
 
 sealed interface SdArrayElement {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DisclosedClaimSetTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DisclosedClaimSetTest.kt
@@ -198,10 +198,11 @@ class DisclosedClaimSetTest {
                 plain(plainClaims)
                 claimsToBeDisclosed.forEach { c -> structured(c.key) { flat(c.value.jsonObject) } }
             }
+            val numOfDecoys = 4
             val disclosedJsonObject = DisclosuresCreator(
                 hashAlgorithm,
                 SaltProvider.Default,
-                3,
+                numOfDecoys,
 
             ).discloseSdJwt(sdJwtElements).getOrThrow()
 
@@ -212,7 +213,7 @@ class DisclosedClaimSetTest {
              */
             fun assertJwtClaimSetSize() {
                 // otherClaims size +  "_sd_alg" + "_sd"
-                val expectedJwtClaimSetSize = plainClaims.size + 1 + claimsToBeDisclosed.size
+                val expectedJwtClaimSetSize = plainClaims.size + 1 + claimsToBeDisclosed.size + (if (numOfDecoys > 0) 1 else 0)
                 assertEquals(expectedJwtClaimSetSize, jwtClaimSet.size, "Incorrect jwt payload attribute number")
             }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SelectivelyDisclosedArrayElementTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SelectivelyDisclosedArrayElementTest.kt
@@ -16,19 +16,12 @@
 package eu.europa.ec.eudi.sdjwt
 
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 import org.junit.jupiter.api.Test
 
-typealias ArrayClaim = Pair<String, JsonArray>
-
-class ArrayElementTest {
-
-    private val saltProvider = SaltProvider.Default
-    private val hashAlgorithm = HashAlgorithm.SHA_256
-
+class SelectivelyDisclosedArrayElementTest {
     @Test
     fun simple() {
         val sdJwtElements = sdJwt {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Utils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Utils.kt
@@ -35,7 +35,11 @@ val json = Json { prettyPrint = true }
 fun DisclosedClaims.print() {
     println("Found ${disclosures.size} disclosures")
     disclosures.forEach { d ->
-        println("\t - ${d.claim()}")
+        val kind = when (d) {
+            is Disclosure.ArrayElement -> "\t - ArrayEntry ${d.claim().value()}"
+            is Disclosure.ObjectProperty -> "\t - Claim ${d.claim()}"
+        }
+        println(kind)
     }
     claimSet.also { println(json.encodeToString(it)) }
 }


### PR DESCRIPTION
This PR adds the Example 4 of specification which issues an SD-JWT for EUDI PID

In order to support this the following functionality was added/changed:

* When Structured Selectively Disclosed claims have only plain claims, library used to simplified into plain claims. This changed to be able to include decoys. 
* Added the ability nesting a Selectively Disclosed Array or Structured Disclosed Claim into flat disclosed claims. Though, it is not clear, why authors of SD-JWT have chosen such a complex feature (Having deeply nested selectively disclosed claims)