### PR TITLE
Add factory method for creating a KeyBindingJwtVerifier

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
@@ -215,7 +215,7 @@ sealed interface KeyBindingVerifier {
 
     companion object {
 
-        private fun KeyBindingError.asException(): SdJwtVerificationException =
+        internal fun KeyBindingError.asException(): SdJwtVerificationException =
             KeyBindingFailed(this).asException()
     }
 }


### PR DESCRIPTION
This PR adds a convenient factory method, that creates a Key Binding JWT verifier which applies the following rules to Key Binding JWT

- Header must contain the algorithm claim (`alg), containing the algorithm used by the holder to sign the Key Binding JWT
- Header must contain a type claim (`typ`) equal to `kb+jwt`
- The payload of the Key binding JWT must contain the claims `aud`, `iat` and `nonce`
- If verifier provided a challenge, this challenge must be found as is, within the Key Binding JWT payload


The factory method declares two parameters:
- A function to obtain the Holder Public Key, from within the payload of the JWT part of the SD-JWT. If not provided, it is assumed that the `Issuer` used the confirmation claim (`cnf`) to include by value (claim `jwk`) the holder's public key
- Optionally, a verifier's challenge, to be signed. If it is omitted, holder must include in the Key Binding JWT payload claims  `aud`, `iat` and `nonce`