### PR TITLE
Replace the Combined Issuance & Presentation format with the unified format

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ Library's SD-JWT DSL leverages the DSL provided by
 
 ## Use cases supported
 
-- [Issuance](#issuance): As an Issuer use the library to issue a SD-JWT (in Combined Issuance Format)
-- [Holder Verification](#holder-verification): As Holder verify a SD-JWT (in Combined Issuance Format) issued by an
-  Issuer
-- [Presentation Verification](#presentation-verification): As a Verifier verify SD-JWT in Combined Presentation Format or in Envelope Format
+- [Issuance](#issuance): As an Issuer use the library to issue a SD-JWT 
+- [Holder Verification](#holder-verification): As Holder verify a SD-JWT issued by an Issuer
+- [Presentation Verification](#presentation-verification): As a Verifier verify SD-JWT in simple or in Enveloped Format
 - [Recreate initial claims](#recreate-original-claims): Given a SD-JWT recreate the original claims
 
 ## Issuance
@@ -50,51 +49,49 @@ In the example bellow, Issuer decides to issue an SD-JWT as follows:
 - Uses his RSA key pair to sign the SD-JWT
 
 ```kotlin
-
 import com.nimbusds.jose.crypto.RSASigner
 import com.nimbusds.jose.jwk.RSAKey
 import eu.europa.ec.eudi.sdjwt.*
 
-val iss = "Issuer"
-val issuerKeyPair: RSAKey
-val sdJwt: SdJwt.Issuance<NimbusSignedJWT> =
-  signedSdJwt(signer = RSASigner(issuerKeyPair), signAlgorithm = JWSAlgorithm.RS256) {
-
-        sub("6c5c0a49-b589-431d-bae7-219122a9ec2c")
-        iss("https://example.com/issuer")
-        iat(1516239022)
-        exp(1735689661)
-
-        structured("address") {
-            sd {
-                put("street_address", "Schulstr. 12")
-                put("locality", "Schulpforta")
-                put("region", "Sachsen-Anhalt")
-                put("country", "DE")
-            }
-        }
-    }.serialize()
-
+val issuerKeyPair: RSAKey = TODO("Omitted")
+val sdJwtSpec = sdJwt {
+  plain {
+      sub("6c5c0a49-b589-431d-bae7-219122a9ec2c")
+      iss("https://example.com/issuer")
+      iat(1516239022)
+      exp(1735689661)
+  }
+  structured("address") {
+    sd {
+      put("street_address", "Schulstr. 12")
+      put("locality", "Schulpforta")
+      put("region", "Sachsen-Anhalt")
+      put("country", "DE")
+    }
+  }
+}
+val issuer = SdJwtIssuer.nimbus(signer = RSASigner(issuerKeyPair), signAlgorithm = JWSAlgorithm.RS256)
+val sdJwt: String = issuer.issue(sdJwtSpec).getOrThrow().serialize()
 ```
+
 Please check [KeyBindingTest](src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt) for a more advanced
 issuance scenario, including adding to the SD-JWT, holder public key, to leverage key binding.
 
 ## Holder Verification
 
-In this case, the SD-JWT is expected to be in Combined Issuance format.
+In this case, the SD-JWT is expected to be in serialized form.
 
 `Holder` must know:
 
 - the public key of the `Issuer` and the algorithm used by the Issuer to sign the SD-JWT
 
 ```kotlin
-
 import com.nimbusds.jose.crypto.ECDSAVerifier
 import com.nimbusds.jose.jwk.*
 import eu.europa.ec.eudi.sdjwt.*
 
 val unverifiedSdJwt: String = "..."
-val issuerPubKey: ECPublicKey
+val issuerPubKey: ECPublicKey = TODO("Omitted")
 val jwtSignatureVerifier = ECDSAVerifier(issuerPubKey).asJwtVerifier()
 
 val issued: SdJwt.Issuance<JwtAndClaims> =
@@ -107,7 +104,7 @@ val (jwtAndClaims, disclosures) = issued
 
 ## Presentation Verification
 
-### In combined presentation format
+### In simple (not enveloped) format
 
 In this case, the SD-JWT is expected to be in Combined Presentation format.
 Verifier should know the public key of the Issuer and the algorithm used by the Issuer
@@ -121,7 +118,7 @@ import com.nimbusds.jose.jwk.*
 import com.nimbusds.jose.crypto.ECDSAVerifier
 
 val unverifiedSdJwt: String = "..."
-val issuerPubKey: ECPublicKey
+val issuerPubKey: ECPublicKey = TODO("Omitted")
 val jwtSignatureVerifier = ECDSAVerifier(issuerPubKey).asJwtVerifier()
 
 //
@@ -140,7 +137,7 @@ val sdJwt: SdJwt.Presentation<JwtAndClaims, JwtAndClaims> =
 Please check [KeyBindingTest](src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt) for a more advanced
 presentation scenario which includes key binding
 
-### In envelope format
+### In enveloped format
 
 In this case, the SD-JWT is expected to be in envelope format.
 Verifier should know
@@ -158,10 +155,10 @@ import java.time.Duration
 
 val unverifiedEnvelopeJwt: String = "..."
 // This is the SD-JWT issuer's key
-val issuerPubKey: ECPublicKey
+val issuerPubKey: ECPublicKey = TODO("Omitted")
 val jwtSignatureVerifier = ECDSAVerifier(issuerPubKey).asJwtVerifier()
 // This is the envelope JWT issuer (the holder) key 
-val holderPubKey: ECPublicKey
+val holderPubKey: ECPublicKey = TODO("Omitted")
 val envelopeJwtVerifier = ECDSAVerifier(holderPubKey).asJwtVerifier()
 
 val sdJwt : SdJwt.Presentation<JwtAndClaims, Nothing> = 
@@ -182,16 +179,17 @@ recreated. This includes the claims that are always disclosed (included in the J
 the digests replaced by selectively disclosable claims found in disclosures.
 
 ```kotlin
+
 val iss = "Issuer"
-val issuerKeyPair: RSAKey
+val issuerKeyPair: RSAKey = TODO("Omitted")
 val sdJwt: SdJwt.Issuance<NimbusSignedJWT> =
   signedSdJwt(signer = RSASigner(issuerKeyPair), signAlgorithm = JWSAlgorithm.RS256) {
-
-        sub("6c5c0a49-b589-431d-bae7-219122a9ec2c")
-        iss("https://example.com/issuer")
-        iat(1516239022)
-        exp(1735689661)
-
+        plain {
+            sub("6c5c0a49-b589-431d-bae7-219122a9ec2c")
+            iss("https://example.com/issuer")
+            iat(1516239022)
+            exp(1735689661)
+        }
         structured("address") {
             sd {
                 put("street_address", "Schulstr. 12")

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -237,7 +237,7 @@ fun SdJwtIssuer.Companion.nimbus(
 
 private object NimbusSdJwtIssuerFactory {
 
-    private const val allowSymmetric = true
+    private const val AllowAssymetric = true
 
     /**
      * Factory method for creating a [SdJwtIssuer] that uses Nimbus
@@ -259,7 +259,7 @@ private object NimbusSdJwtIssuerFactory {
     ): SdJwtIssuer<NimbusSignedJWT> = SdJwtIssuer(sdJwtFactory) { unsignedSdJwt ->
 
         val (claims, disclosures) = unsignedSdJwt
-        require(allowSymmetric || signAlgorithm.isAsymmetric()) { "Only asymmetric algorithm can be used" }
+        require(AllowAssymetric || signAlgorithm.isAsymmetric()) { "Only asymmetric algorithm can be used" }
         val signedJwt = sign(signer, signAlgorithm, jwsHeaderCustomization)(claims).getOrThrow()
         SdJwt.Issuance(signedJwt, disclosures)
     }
@@ -289,7 +289,7 @@ private object NimbusSdJwtIssuerFactory {
     /**
      * Indicates whether an [NimbusJWSAlgorithm] is asymmetric
      * @receiver the algorithm to check
-     * @return true if algorithm is asymmetric.
+     * @return true if the algorithm is asymmetric.
      */
     private fun NimbusJWSAlgorithm.isAsymmetric(): Boolean = NimbusJWSAlgorithm.Family.SIGNATURE.contains(this)
 }
@@ -308,8 +308,8 @@ private object NimbusSdJwtIssuerFactory {
  * @return the SD-JWT in either  Combined Issuance or Combined Presentation format depending on the case
  */
 fun <JWT : NimbusJWT, HB_JWT : NimbusJWT> SdJwt<JWT, HB_JWT>.serialize(): String = when (this) {
-    is SdJwt.Issuance<JWT> -> toCombinedIssuanceFormat(NimbusJWT::serialize)
-    is SdJwt.Presentation<JWT, HB_JWT> -> toCombinedPresentationFormat(NimbusJWT::serialize, NimbusJWT::serialize)
+    is SdJwt.Issuance<JWT> -> serialize(NimbusJWT::serialize)
+    is SdJwt.Presentation<JWT, HB_JWT> -> serialize(NimbusJWT::serialize, NimbusJWT::serialize)
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtSerialization.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtSerialization.kt
@@ -21,32 +21,32 @@ import kotlinx.serialization.json.put
 import java.time.Instant
 
 /**
- * Serializes a [SdJwt.Issuance] to Combined Issuance Format
+ * Serializes an [SdJwt.Issuance]
  *
  * @param serializeJwt a function to serialize the [JWT]
  * @param JWT the type representing the JWT part of the SD-JWT
  * @receiver the SD-JWT to serialize
- * @return the Combined Issuance format of the SD-JWT
+ * @return the serialized format of the SD-JWT
  */
-fun <JWT> SdJwt.Issuance<JWT>.toCombinedIssuanceFormat(
+fun <JWT> SdJwt.Issuance<JWT>.serialize(
     serializeJwt: (JWT) -> String,
 ): String {
     val serializedJwt = serializeJwt(jwt)
     val serializedDisclosures = disclosures.concat()
-    return "$serializedJwt$serializedDisclosures"
+    return "$serializedJwt$serializedDisclosures~"
 }
 
 /**
- * Serialized a [SdJwt.Presentation] to Combined Presentation Format
+ * Serializes an [SdJwt.Presentation]
  *
  * @param serializeJwt a function to serialize the [JWT]
  * @param JWT the type representing the JWT part of the SD-JWT
  * @param serializeKeyBindingJwt a function to serialize the [KB_JWT]
  * @param KB_JWT the type representing the Key Binding part of the SD
  * @receiver the SD-JWT to serialize
- * @return the Combined Presentation format of the SD-JWT
+ * @return the serialized format of the SD-JWT
  */
-fun <JWT, KB_JWT> SdJwt.Presentation<JWT, KB_JWT>.toCombinedPresentationFormat(
+fun <JWT, KB_JWT> SdJwt.Presentation<JWT, KB_JWT>.serialize(
     serializeJwt: (JWT) -> String,
     serializeKeyBindingJwt: (KB_JWT) -> String,
 ): String {
@@ -55,9 +55,9 @@ fun <JWT, KB_JWT> SdJwt.Presentation<JWT, KB_JWT>.toCombinedPresentationFormat(
     val serializedKbJwt = keyBindingJwt?.run(serializeKeyBindingJwt) ?: ""
     return "$serializedJwt$serializedDisclosures~$serializedKbJwt"
 }
-fun <JWT> SdJwt.Presentation<JWT, Nothing>.toCombinedPresentationFormat(
+fun <JWT> SdJwt.Presentation<JWT, Nothing>.serialize(
     serializeJwt: (JWT) -> String,
-): String = toCombinedPresentationFormat(serializeJwt, { it })
+): String = this@serialize.serialize(serializeJwt, { it })
 
 /**
  * Concatenates the given disclosures into a single string, separated by
@@ -123,7 +123,7 @@ fun <JWT, ENVELOPED_JWT> SdJwt.Presentation<JWT, *>.toEnvelopedFormat(
     serializeJwt: (JWT) -> String,
     signEnvelop: (Claims) -> Result<ENVELOPED_JWT>,
 ): Result<ENVELOPED_JWT> {
-    val sdJwtInCombined = noKeyBinding().toCombinedPresentationFormat(serializeJwt)
+    val sdJwtInCombined = noKeyBinding().serialize(serializeJwt)
     val envelopedClaims = otherClaims.toMutableMap()
     envelopedClaims["_sd_jwt"] = JsonPrimitive(sdJwtInCombined)
     return signEnvelop(envelopedClaims)

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -275,7 +275,7 @@ class HolderActor(private val holderKey: ECKey) {
         holderDebug("Presenting credentials ...")
         val keyBindingJwt = keyBindingJwt(verifierQuery.challenge.asJson())
         return credentialSdJwt!!.present(keyBindingJwt, verifierQuery.whatToDisclose)
-            .toCombinedPresentationFormat({ it }, { it })
+            .serialize({ it }, { it })
     }
 
     private fun keyBindingJwt(verifierChallenge: JsonObject): String =

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyIssuanceTest.kt
@@ -24,7 +24,16 @@ class SdJwtVerifierVerifyIssuanceTest {
 
     @Test
     fun simple() {
-        verifyIssuanceSuccess(JwtSignatureVerifier.NoSignatureValidation, unverifiedSdJwt = "$jwt~$d1")
+        verifyIssuanceSuccess(JwtSignatureVerifier.NoSignatureValidation, unverifiedSdJwt = "$jwt~$d1~")
+    }
+
+    @Test
+    fun `when sd-jwt doesn't end in ~ raise UnexpectedKeyBindingJwt`() {
+        verifyIssuanceExpectingError(
+            VerificationError.KeyBindingFailed(KeyBindingError.UnexpectedKeyBindingJwt),
+            JwtSignatureVerifier.NoSignatureValidation,
+            "$jwt~$d1",
+        )
     }
 
     private fun verifyIssuanceSuccess(


### PR DESCRIPTION
In draft 4 of the SD-JWT specification there used to be two different serialization formats for Issued or Presented SD-JWTs, referred with the name `Combined Issuance Format` & `Combined Presentation Format`

In draft 5, there is a common format for serializing the SD-JWT (both issuance and presentation), described [here](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-05.html#name-sd-jwt-structure)

The PR implemented this unified serialization rules.

As a side note: We preserved in our model the distinction between an Issuance & Presentation SD-JWT, since they have different semantics 
- Issuance can have no Key binding JWT
- Issuance / Presentation disclosures have different verification rules