### PR TITLE
fixed secret name

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -9,5 +9,4 @@ jobs:
       uses: eu-digital-identity-wallet/eudi-infra-ci/.github/workflows/sast_bt.yml@main
       secrets:
        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-       CI: true
+       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Github token was not being passed to reusable workflow due to conflict with system-reserved variable.