### PR TITLE
Helper method for the parsing of a sdjwt string to retrieve claims

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.sdjwt
 
+import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.sdjwt.KeyBindingError.*
 import eu.europa.ec.eudi.sdjwt.KeyBindingVerifier.Companion.asException
 import eu.europa.ec.eudi.sdjwt.KeyBindingVerifier.MustNotBePresent
@@ -237,6 +238,23 @@ typealias JwtAndClaims = Pair<Jwt, Claims>
  * and [Combined Presentation Format][verifyPresentation]
  */
 object SdJwtVerifier {
+
+    /**
+     * Parses an SD-JWT to extract the JWT and its claims.
+     *
+     * This function takes an unverified SD-JWT, parses it to separate the JWT and its disclosures,
+     * and then constructs an issuance object containing the JWT and its claims along with the unique disclosures.
+     *
+     * @param unverifiedSdJwt the unverified SD-JWT to be parsed
+     * @return an issuance object containing the JWT and its claims, and the unique disclosures
+     */
+    fun sdJWTParser(unverifiedSdJwt: String): SdJwt.Issuance<JwtAndClaims> {
+        val (unverifiedJwt, unverifiedDisclosures) = parseIssuance(unverifiedSdJwt)
+        val parsedJwt = SignedJWT.parse(unverifiedJwt)
+        val jwtClaims = parsedJwt.jwtClaimsSet.asClaims()
+        val disclosures = uniqueDisclosures(unverifiedDisclosures)
+        return SdJwt.Issuance(unverifiedJwt to jwtClaims, disclosures)
+    }
 
     /**
      * Verifies an SD-JWT (in non enveloped, simple format)


### PR DESCRIPTION
Hey guys. How are you? I found this use case and I think it would be useful to add.

As a developer I may want to process an SDJWT without verifying.

Having a helper function that would initialise a holder SdJwt, would simplify this process.
This way I could initialise a SdJWT without the need of having a suspended function.

This would be very useful when as a holder you want to process the claims of a saved SDJwt without the need of verifying it again.
I understand there is JwtSignatureVerifier.Companion.NoSignatureValidation but it still requires to be suspended.

Closes #200