### PR TITLE
Use kid in SdJwtVcVerifier when using issuer metadata

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -209,7 +209,7 @@ private suspend fun issuerJwsKeySelector(
 /**
  * The source from which to get Issuer's public key
  */
-private sealed interface SdJwtVcIssuerPublicKeySource {
+internal sealed interface SdJwtVcIssuerPublicKeySource {
 
     data class Metadata(val iss: Url, val kid: String?) : SdJwtVcIssuerPublicKeySource
 
@@ -226,7 +226,7 @@ private sealed interface SdJwtVcIssuerPublicKeySource {
 private const val HTTPS_URI_SCHEME = "https"
 private const val DID_URI_SCHEME = "did"
 
-private fun keySource(jwt: SignedJWT): SdJwtVcIssuerPublicKeySource? {
+internal fun keySource(jwt: SignedJWT): SdJwtVcIssuerPublicKeySource? {
     val kid = jwt.header.keyID
     val certChain = jwt.header.x509CertChain.orEmpty().mapNotNull { X509CertUtils.parse(it.decode()) }
     val iss = jwt.jwtClaimsSet.issuer

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -194,7 +194,7 @@ private suspend fun issuerJwsKeySelector(
 
     suspend fun fromDid(source: DIDUrl): JWSKeySelector<SecurityContext>? =
         lookup
-            ?.lookup(source.did, source.didUrl)
+            ?.lookup(source.iss, source.kid)
             ?.takeIf { it.isNotEmpty() }
             ?.let { publicKeys -> JWSVerificationKeySelector(algorithm, ImmutableJWKSet(JWKSet(publicKeys))) }
 
@@ -220,7 +220,7 @@ internal sealed interface SdJwtVcIssuerPublicKeySource {
     data class X509SanDns(val iss: Url, override val chain: List<X509Certificate>) : X509CertChain
     data class X509SanURI(val iss: Url, override val chain: List<X509Certificate>) : X509CertChain
 
-    data class DIDUrl(val did: String, val didUrl: String?) : SdJwtVcIssuerPublicKeySource
+    data class DIDUrl(val iss: String, val kid: String?) : SdJwtVcIssuerPublicKeySource
 }
 
 private const val HTTPS_URI_SCHEME = "https"
@@ -262,7 +262,6 @@ internal fun keySource(jwt: SignedJWT): SdJwtVcIssuerPublicKeySource? {
             }
 
         issScheme == DID_URI_SCHEME && certChain.isEmpty() -> {
-            // do not use Url for DIDs. Url adds localhost as a host when parsing DIDs. use the original value instead.
             DIDUrl(iss, kid)
         }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -211,8 +211,7 @@ private suspend fun issuerJwsKeySelector(
  */
 private sealed interface SdJwtVcIssuerPublicKeySource {
 
-    @JvmInline
-    value class Metadata(val iss: Url) : SdJwtVcIssuerPublicKeySource
+    data class Metadata(val iss: Url, val kid: String?) : SdJwtVcIssuerPublicKeySource
 
     interface X509CertChain : SdJwtVcIssuerPublicKeySource {
         val chain: List<X509Certificate>
@@ -247,7 +246,7 @@ private fun keySource(jwt: SignedJWT): SdJwtVcIssuerPublicKeySource? {
 
     return when {
         issUrl == null -> null
-        issScheme == HTTPS_URI_SCHEME && certChain.isEmpty() && kid == null -> Metadata(issUrl)
+        issScheme == HTTPS_URI_SCHEME && certChain.isEmpty() -> Metadata(issUrl, kid)
 
         certChain.isNotEmpty() && kid == null ->
             when (issScheme) {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt.vc
+
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.KeyUse
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import eu.europa.ec.eudi.sdjwt.*
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private object SampleIssuer {
+    val iss = Url("https://example.com")
+    private val alg = JWSAlgorithm.ES256
+    val issuerKey = ECKeyGenerator(Curve.P_256)
+        .keyID("someKeyId")
+        .keyUse(KeyUse.SIGNATURE)
+        .algorithm(alg)
+        .generate()
+    val issuerMeta = run {
+        val jwks = Json.parseToJsonElement(JWKSet(issuerKey.toPublicJWK()).toString())
+        buildJsonObject {
+            put("issuer", iss.toString())
+            put("jwks", jwks)
+        }
+    }
+
+    fun issuer(kid: String?) =
+        SdJwtIssuer.nimbus(signer = ECDSASigner(issuerKey), signAlgorithm = alg) {
+            type(JOSEObjectType(SD_JWT_VC_TYPE))
+            kid?.let { keyID(it) }
+        }
+}
+
+class SdJwtVcVerifierTest {
+
+    @Test
+    fun `keySource() should return a Metadata when iss is a https url`() {
+        val expectedSource = SdJwtVcIssuerPublicKeySource.Metadata(Url("https://example.com"), null)
+        testForMetaDataSource(expectedSource)
+    }
+
+    @Test
+    fun `keySource() should return a Metadata when iss is a https url and kid is provided`() {
+        val expectedSource = SdJwtVcIssuerPublicKeySource.Metadata(Url("https://example.com"), "some-kid")
+        testForMetaDataSource(expectedSource)
+    }
+
+    @Test
+    fun `SdJwtVcVerifier should verify with metadata when iss is HTTPS url using kid`() = runTest {
+        // In case the issuer uses the KID
+        val unverifiedSdJwt = run {
+            val issuer = SampleIssuer.issuer(kid = SampleIssuer.issuerKey.keyID) // correct kid
+            val sdJwtSpec = sdJwtSpec(SampleIssuer.iss)
+            issuer.issue(sdJwtSpec).getOrThrow().serialize()
+        }
+
+        val verifier =
+            SdJwtVcVerifier(httpClientFactory = { httpClientReturning(SampleIssuer.issuerMeta) })
+
+        assertDoesNotThrow {
+            verifier.verifyIssuance(unverifiedSdJwt).getOrThrow()
+        }
+    }
+
+    @Test
+    fun `SdJwtVcVerifier should verify with metadata when iss is HTTPS url and no kid`() = runTest {
+        val unverifiedSdJwt = run {
+            val issuer = SampleIssuer.issuer(kid = null) // no kid
+            val sdJwtSpec = sdJwtSpec(SampleIssuer.iss)
+            issuer.issue(sdJwtSpec).getOrThrow().serialize()
+        }
+
+        val verifier =
+            SdJwtVcVerifier(httpClientFactory = { httpClientReturning(SampleIssuer.issuerMeta) })
+
+        assertDoesNotThrow {
+            verifier.verifyIssuance(unverifiedSdJwt).getOrThrow()
+        }
+    }
+
+    @Test
+    fun `SdJwtVcVerifier should not verify with metadata when iss is HTTPS url using wrong kid`() = runTest {
+        // In case the issuer uses the KID
+        val unverifiedSdJwt = run {
+            val issuer = SampleIssuer.issuer(kid = "wrong kid")
+            val sdJwtSpec = sdJwtSpec(SampleIssuer.iss)
+            issuer.issue(sdJwtSpec).getOrThrow().serialize()
+        }
+
+        val verifier =
+            SdJwtVcVerifier(httpClientFactory = { httpClientReturning(SampleIssuer.issuerMeta) })
+
+        val exception = assertThrows<SdJwtVerificationException> {
+            verifier.verifyIssuance(unverifiedSdJwt).getOrThrow()
+        }
+        assertEquals(VerificationError.InvalidJwt, exception.reason)
+    }
+
+    private fun sdJwtSpec(iss: Url) = sdJwt {
+        iss(iss.toString())
+        sd("foo", "bar")
+        iat(Instant.now().toEpochMilli())
+    }
+
+    private fun httpClientReturning(issuerMeta: JsonObject): HttpClient =
+        HttpClient { _ ->
+            respond(
+                issuerMeta.toString(),
+                HttpStatusCode.OK,
+                headers { append(HttpHeaders.ContentType, ContentType.Application.Json) },
+            )
+        }
+}
+
+@Suppress("TestFunctionName")
+private fun HttpClient(handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData): HttpClient =
+    HttpClient(MockEngine(handler)) {
+        expectSuccess = true
+        install(ContentNegotiation) {
+            json()
+        }
+    }
+
+private fun testForMetaDataSource(expectedSource: SdJwtVcIssuerPublicKeySource.Metadata) {
+    val jwt = run {
+        val header = JWSHeader.Builder(JWSAlgorithm.ES256).apply {
+            type(JOSEObjectType(SD_JWT_VC_TYPE))
+            expectedSource.kid?.let { keyID(it) }
+        }.build()
+        val payload = JWTClaimsSet.Builder().apply {
+            issuer(expectedSource.iss.toString())
+        }.build()
+        SignedJWT(header, payload)
+    }
+
+    val actualSource = keySource(jwt)
+    assertEquals(expectedSource, actualSource)
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -133,8 +133,8 @@ class SdJwtVcVerifierTest {
     fun `keySource() should return a DID when iss is a DID and kid is provided`() {
         val expectedSource =
             SdJwtVcIssuerPublicKeySource.DIDUrl(
-                did = "did:ebsi:zkC6cUFUs3FiRp2xedNwih2",
-                didUrl = "did:ebsi:zkC6cUFUs3FiRp2xedNwih2#x8x4WxXHoPW7ccEO0zACL_miBfO-V7X_jofc-UEGzw4",
+                iss = "did:ebsi:zkC6cUFUs3FiRp2xedNwih2",
+                kid = "did:ebsi:zkC6cUFUs3FiRp2xedNwih2#x8x4WxXHoPW7ccEO0zACL_miBfO-V7X_jofc-UEGzw4",
             )
         testForDid(expectedSource)
     }
@@ -143,10 +143,10 @@ class SdJwtVcVerifierTest {
         val jwt = run {
             val header = JWSHeader.Builder(JWSAlgorithm.ES256).apply {
                 type(JOSEObjectType(SD_JWT_VC_TYPE))
-                expectedSource.didUrl?.let { keyID(it) }
+                expectedSource.kid?.let { keyID(it) }
             }.build()
             val payload = JWTClaimsSet.Builder().apply {
-                issuer(expectedSource.did)
+                issuer(expectedSource.iss)
             }.build()
             SignedJWT(header, payload)
         }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -102,13 +102,13 @@ private object HttpMock {
 class SdJwtVcVerifierTest {
 
     @Test
-    fun `keySource() should return a Metadata when iss is a https url`() {
+    fun `keySource should return a Metadata when iss is a https url`() {
         val expectedSource = SdJwtVcIssuerPublicKeySource.Metadata(Url("https://example.com"), null)
         testForMetaDataSource(expectedSource)
     }
 
     @Test
-    fun `keySource() should return a Metadata when iss is a https url and kid is provided`() {
+    fun `keySource should return a Metadata when iss is a https url and kid is provided`() {
         val expectedSource = SdJwtVcIssuerPublicKeySource.Metadata(Url("https://example.com"), "some-kid")
         testForMetaDataSource(expectedSource)
     }
@@ -130,7 +130,7 @@ class SdJwtVcVerifierTest {
     }
 
     @Test
-    fun `keySource() should return a DID when iss is a DID and kid is provided`() {
+    fun `keySource should return a DIDUrl when iss is a DID and kid is provided`() {
         val expectedSource =
             SdJwtVcIssuerPublicKeySource.DIDUrl(
                 iss = "did:ebsi:zkC6cUFUs3FiRp2xedNwih2",
@@ -156,7 +156,7 @@ class SdJwtVcVerifierTest {
     }
 
     @Test
-    fun `SdJwtVcVerifier should verify with metadata when iss is HTTPS url using kid`() = runTest {
+    fun `SdJwtVcVerifier should verify an SD-JWT-VC when iss is HTTPS url using kid`() = runTest {
         val unverifiedSdJwt = SampleIssuer.issueUsingKid(kid = SampleIssuer.KEY_ID)
         val verifier = SdJwtVcVerifier({ HttpMock.clientReturning(SampleIssuer.issuerMeta) })
 
@@ -166,7 +166,7 @@ class SdJwtVcVerifierTest {
     }
 
     @Test
-    fun `SdJwtVcVerifier should verify with metadata when iss is HTTPS url and no kid`() = runTest {
+    fun `SdJwtVcVerifier should verify an SD-JWT-VC when iss is HTTPS url and no kid`() = runTest {
         val unverifiedSdJwt = SampleIssuer.issueUsingKid(kid = null)
         val verifier = SdJwtVcVerifier({ HttpMock.clientReturning(SampleIssuer.issuerMeta) })
 
@@ -176,7 +176,7 @@ class SdJwtVcVerifierTest {
     }
 
     @Test
-    fun `SdJwtVcVerifier should not verify with metadata when iss is HTTPS url using wrong kid`() = runTest {
+    fun `SdJwtVcVerifier should not verify an SD-JWT-VC when iss is HTTPS url using wrong kid`() = runTest {
         // In case the issuer uses the KID
         val unverifiedSdJwt = SampleIssuer.issueUsingKid("wrong kid")
         val verifier = SdJwtVcVerifier({ HttpMock.clientReturning(SampleIssuer.issuerMeta) })


### PR DESCRIPTION
The PR will remove the restriction to not have kid in order to trigger the resolution of the issuer's pub key using its metadata.
Closes #197 

It seems that this is the only change needed, given that the underlying [Nimbus provided JWSVerificationKeySelector](https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-sdjwt-kt/blob/29fb44e9071c37411267a4a26b5ff754a2664823/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt#L186C13-L186C39) already takes into account kid to filter the provided JWK set.