### PR TITLE
Add to Dsl option for desired digests (disclose + decoy digests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ By default, library doesn't add decoy digests to the issued SD-JWT.
 If issuer wants to use digests, it can do so using the DSL.
 
 DSL functions that mark a container comprised of potentially selectively disclosable   
-elements, such as `sdJwtc{}`, `structured{}` e.t,c, accept
+elements, such as `sdJwt{}`, `structured{}` e.t,c, accept
 an optional parameter named `digestNumberHint: Int? = null`.
 
 The issuer can use this parameter in order to set the minimum  number of digests

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ the [EUDI Wallet Reference Implementation project description](https://github.co
     * [Holder Presentation](#holder-presentation)
     * [Presentation Verification](#presentation-verification)
     * [Recreate initial claims](#recreate-original-claims)
+* [Decoy digests](#decoy-digests)
 * [DSL Examples](#dsl-examples)
 * [SD-JWT VC support](#sd-jwt-vc-support)
 * [How to contribute](#how-to-contribute)
@@ -288,6 +289,43 @@ The claims contents would be
   "iat": 1516239022
 }
 ```
+## Decoy digests
+
+By default, library doesn't add decoy digests to the issued SD-JWT.
+If issuer wants to use digests, it can do so using the DSL.
+
+DSL functions that mark a container comprised of potentially selectively disclosable   
+elements, such as `sdJwtc{}`, `structured{}` e.t,c, accept
+an optional parameter named `digestNumberHint: Int? = null`.
+
+The issuer can use this parameter in order to set the minimum  number of digests
+for the immediate level of this container. Library will make sure that
+the underlying digests array will have at minimum a length equal to `digestNumberHint`.
+
+Initially, during issuance, the digests array will contain disclosure digests and if needed,
+additional decoy digests to reach the hint provided. If the array
+contains more disclosure digests than the hint, no decoys will be added.
+
+
+```kotlin
+sdJwt(digestNumberHint = 5) {
+  // This 5 guarantees that at least 5 digests will be found
+  // to the digest array, regardless of the content of the SD-JWT
+    
+  structured("address", digestNumberHint = 10) {
+    // This affects the nested array of the digests that will 
+    // have at list 10 digests.
+  }
+  
+  recursive("address1", digestNumberHint = 8) {
+      // This will affect the digests array that will be found
+      // in the disclosure of this recursively disclosable item
+  }
+}
+```
+In addition to the DSL defined hints, the issuer may set a global hint to the `SdJwtFactory`.
+This will be used as a fallback limit for every container of selectively disclosable elements
+that don't explicit provide a limit.
 
 ## DSL Examples
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ If issuer wants to use digests, it can do so using the DSL.
 
 DSL functions that mark a container comprised of potentially selectively disclosable   
 elements, such as `sdJwt{}`, `structured{}` e.t,c, accept
-an optional parameter named `digestNumberHint: Int? = null`.
+an optional parameter named `minimumDigests: Int? = null`.
 
 The issuer can use this parameter in order to set the minimum  number of digests
 for the immediate level of this container. Library will make sure that
@@ -312,15 +312,31 @@ sdJwt(digestNumberHint = 5) {
   // This 5 guarantees that at least 5 digests will be found
   // to the digest array, regardless of the content of the SD-JWT
     
-  structured("address", digestNumberHint = 10) {
+  structured("address", minimumDigests = 10) {
     // This affects the nested array of the digests that will 
     // have at list 10 digests.
   }
   
-  recursive("address1", digestNumberHint = 8) {
+  recursive("address1", minimumDigests = 8) {
       // This will affect the digests array that will be found
       // in the disclosure of this recursively disclosable item
+      // the whole object will be embedded in its parent
+      // as a single digest
   }
+
+  sdArray("evidence", minimumDigests = 2) {
+    // Array will have at least 2 digests
+    // regardless of its elements
+  }
+
+  recursiveArray("evidence1", minimumDigests = 2) {
+    // Array will have at least 2 digests
+    // regardless of its elements
+    // the whole array will be embedded in its parent  
+    // as a single digest  
+  }
+
+  
 }
 ```
 In addition to the DSL defined hints, the issuer may set a global hint to the `SdJwtFactory`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project properties
 group=eu.europa.ec.eudi
-version=0.4.1-SNAPSHOT
+version=0.5.0-SNAPSHOT
 
 # Kotlin configuration
 kotlin.code.style=official

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DecoyGen.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DecoyGen.kt
@@ -15,8 +15,6 @@
  */
 package eu.europa.ec.eudi.sdjwt
 
-import kotlin.random.Random
-
 /**
  * Generates decoy [DisclosureDigest]
  */
@@ -40,24 +38,14 @@ fun interface DecoyGen {
         else (1..numOfDecoys).map { gen(hashingAlgorithm) }.toSet()
     }
 
-    /**
-     * Produces a set of decoy [DisclosureDigest]
-     * The number of decoys is random and up to [numOfDecoysLimit]
-     *
-     * @param hashingAlgorithm the algorithm to be used for producing the decoy
-     * @param numOfDecoysLimit the upper limit of the decoys to generate
-     * @return a series of decoy [DisclosureDigest]
-     */
-    fun genUpTo(hashingAlgorithm: HashAlgorithm, numOfDecoysLimit: Int): Set<DisclosureDigest> =
-        gen(hashingAlgorithm, if (numOfDecoysLimit >= 1) Random.nextInt(1, numOfDecoysLimit) else 0)
-
     companion object {
         /**
          * Default implementation of [DecoyGen] which produces random decoy [DisclosureDigest]
          */
         val Default: DecoyGen by lazy {
             DecoyGen { hashingAlgorithm ->
-                val saltProvider = SaltProvider.randomSaltProvider(Random.nextInt(12, 24))
+                val numberOfBytes = 12..24
+                val saltProvider = SaltProvider.randomSaltProvider(numberOfBytes.random())
                 val random = saltProvider.salt()
                 DisclosureDigest.digest(hashingAlgorithm, random).getOrThrow()
             }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -223,10 +223,11 @@ inline fun signedSdJwt(
     signer: NimbusJWSSigner,
     signAlgorithm: NimbusJWSAlgorithm,
     sdJwtFactory: SdJwtFactory = SdJwtFactory.Default,
+    desiredDigests: Int? = null,
     builderAction: SdObjectBuilder.() -> Unit,
 ): SdJwt.Issuance<NimbusSignedJWT> {
     val issuer = SdJwtIssuer.nimbus(sdJwtFactory, signer, signAlgorithm)
-    val sdJwtElements = sdJwt(builderAction)
+    val sdJwtElements = sdJwt(desiredDigests, builderAction)
     return issuer.issue(sdJwtElements).getOrThrow()
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -214,6 +214,9 @@ fun SdObjectBuilder.cnf(jwk: NimbusJWK) = cnf(jwk.asJsonObject())
  * @param sdJwtFactory factory for creating the unsigned SD-JWT
  * @param signer the signer that will sign the SD-JWT
  * @param signAlgorithm It MUST use a JWS asymmetric digital signature algorithm.
+ * @param digestNumberHint This is an optional hint, that expresses the number of digests on the immediate level
+ * of this SD-JWT, that the [SdJwtFactory] will try to satisfy. [SdJwtFactory] will add decoy digests if
+ * the number of [DisclosureDigest] is less than the [hint][digestNumberHint]
  *
  * @return signed SD-JWT
  *
@@ -223,11 +226,11 @@ inline fun signedSdJwt(
     signer: NimbusJWSSigner,
     signAlgorithm: NimbusJWSAlgorithm,
     sdJwtFactory: SdJwtFactory = SdJwtFactory.Default,
-    desiredDigests: Int? = null,
+    digestNumberHint: Int? = null,
     builderAction: SdObjectBuilder.() -> Unit,
 ): SdJwt.Issuance<NimbusSignedJWT> {
     val issuer = SdJwtIssuer.nimbus(sdJwtFactory, signer, signAlgorithm)
-    val sdJwtElements = sdJwt(desiredDigests, builderAction)
+    val sdJwtElements = sdJwt(digestNumberHint, builderAction)
     return issuer.issue(sdJwtElements).getOrThrow()
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/RecreateClaims.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/RecreateClaims.kt
@@ -73,117 +73,108 @@ private typealias DisclosurePerDigest = MutableMap<DisclosureDigest, Disclosure>
  */
 private class RecreateClaims(private val visitor: ClaimVisitor?) {
 
-    fun recreateClaims(claims: Claims, disclosures: List<Disclosure>): Claims {
-        val hashAlgorithm = claims.hashAlgorithm() ?: HashAlgorithm.SHA_256
-        return replaceDigestsWithDisclosures(
+    fun recreateClaims(jwtClaims: JsonObject, disclosures: List<Disclosure>): Claims {
+        val hashAlgorithm = jwtClaims.hashAlgorithm() ?: HashAlgorithm.SHA_256
+        return discloseJwt(
             hashAlgorithm,
+            JsonObject(jwtClaims - "_sd_alg"),
             disclosures,
-            claims - "_sd_alg",
         )
     }
 
     /**
-     * Replaces the digests found within [claims] and/or [disclosures] with
+     * Replaces the digests found within [jwtClaims] and/or [disclosures] with
      * the [disclosures]
      *
      * @param hashAlgorithm the hash algorithm used to produce the [digests][DisclosureDigest]
      * @param disclosures the disclosures to use when replacing digests
-     * @param claims the claims to use
+     * @param jwtClaims the claims of the JWT (except _sd_alg)
      *
-     * @return the initial [claims] having all digests replaced by [Disclosure]
+     * @return the initial [jwtClaims] having all digests replaced by [Disclosure]
      * @throws IllegalStateException when not all [disclosures] have been used, which means
-     * that [claims] doesn't contain a [DisclosureDigest] for every [Disclosure]
+     * that [jwtClaims] doesn't contain a [DisclosureDigest] for every [Disclosure]
      */
-    private fun replaceDigestsWithDisclosures(
+    private fun discloseJwt(
         hashAlgorithm: HashAlgorithm,
+        jwtClaims: JsonObject,
         disclosures: List<Disclosure>,
-        claims: Claims,
     ): JsonObject {
         // Recalculate digests, using the hash algorithm
         val disclosuresPerDigest = disclosures.associateBy {
             DisclosureDigest.digest(hashAlgorithm, it.value).getOrThrow()
         }.toMutableMap()
 
-        val recreatedClaims = embedDisclosuresIntoObject(disclosuresPerDigest, claims, JsonPointer.Root)
+        val discloseObject = DiscloseObject(visitor, disclosuresPerDigest)
+        val disclosedClaims = discloseObject(JsonPointer.Root, jwtClaims)
 
         // Make sure, all disclosures have been embedded
         require(disclosuresPerDigest.isEmpty()) {
             "Could not find digests for disclosures ${disclosuresPerDigest.values.map { it.value }}"
         }
-        return recreatedClaims
+        return disclosedClaims
     }
+}
+
+private class DiscloseObject(
+    private val visitor: ClaimVisitor?,
+    private val disclosures: DisclosurePerDigest,
+) {
 
     /**
-     * Embed disclosures into [jsonElement], if the element
-     * is [JsonObject] or a [JsonArray] with [JSON objects][JsonObject],
-     * including nested elements.
-     *
-     * @param disclosures the disclosures to use when replacing digests
-     * @param jsonElement the element to use
-     * @param current the [JsonPointer] of the current element
-     *
-     * @return a json element where all digests have been replaced by disclosed claims
-     */
-    private fun embedDisclosuresIntoElement(
-        disclosures: DisclosurePerDigest,
-        jsonElement: JsonElement,
-        current: JsonPointer,
-    ): JsonElement {
-        fun embedDisclosuresIntoArrayElement(element: JsonElement, index: Int): JsonElement? {
-            val elementPath = current.child(index)
-
-            val sdArrayElement =
-                when (val disclosed = DisclosedArrayElement.of(element)) {
-                    is DisclosedArrayElement.Digest -> {
-                        replaceArrayDigest(disclosures, disclosed.digest, elementPath)
-                    }
-
-                    DisclosedArrayElement.Object -> {
-                        visited(elementPath, null)
-                        element
-                    }
-
-                    DisclosedArrayElement.NotAnObject -> element
-                }
-            return sdArrayElement
-                ?.let { embedDisclosuresIntoElement(disclosures, it, elementPath) }
-        }
-
-        visited(current, null)
-        return when (jsonElement) {
-            is JsonObject -> embedDisclosuresIntoObject(disclosures, jsonElement, current)
-            is JsonArray ->
-                jsonElement
-                    .zip(0..<jsonElement.size)
-                    .mapNotNull { (element, index) -> embedDisclosuresIntoArrayElement(element, index) }
-                    .let { elements -> JsonArray(elements) }
-
-            else -> jsonElement
-        }
-    }
-
-    /**
-     * Embed disclosures into [claims]
+     * Embed disclosures into [jsonObject]
      * Replaces the direct (immediate) digests of the object and
      * then recursively do the same for all elements
      * that are either objects or arrays
      *
-     * @param disclosures the disclosures to use when replacing digests
-     * @param claims the claims to use
-     * @param current the [JsonPointer] of the current element
+     * @param jsonObject the claims to use
+     * @param currentPointer the [JsonPointer] of the current element
      *
-     * @return the given [claims] with the digests, if any, replaced by disclosures, including
+     * @return the given [jsonObject] with the digests, if any, replaced by disclosures, including
      * all nested objects and/or array of objects
      */
-    private fun embedDisclosuresIntoObject(
-        disclosures: DisclosurePerDigest,
-        claims: Claims,
-        current: JsonPointer,
+    operator fun invoke(
+        currentPointer: JsonPointer,
+        jsonObject: JsonObject,
+    ): JsonObject = discloseObject(currentPointer, jsonObject)
+
+    //
+    // Any JSON Element
+    //
+
+    /**
+     * Embed disclosures into [element], if the element
+     * is [JsonObject] or a [JsonArray] with [JSON objects][JsonObject],
+     * including nested elements.
+     *
+     * @param element the element to use
+     * @param currentPointer the [JsonPointer] of the current element
+     *
+     * @return a json element where all digests have been replaced by disclosed claims
+     */
+    private fun discloseElement(
+        currentPointer: JsonPointer,
+        element: JsonElement,
+    ): JsonElement {
+        visited(currentPointer, null)
+        return when (element) {
+            is JsonObject -> discloseObject(currentPointer, element)
+            is JsonArray -> discloseArray(currentPointer, element)
+            else -> element
+        }
+    }
+
+    //
+    // JSON Object
+    //
+
+    private fun discloseObject(
+        currentPointer: JsonPointer,
+        jsonObject: JsonObject,
     ): JsonObject =
-        replaceDirectDigests(disclosures, claims, current)
+        replaceObjectDigests(currentPointer, jsonObject)
             .mapValues { (name, element) ->
-                val nestedPath = current.child(name)
-                embedDisclosuresIntoElement(disclosures, element, nestedPath)
+                val nestedPath = currentPointer.child(name)
+                discloseElement(nestedPath, element)
             }
             .let { obj -> JsonObject(obj) }
 
@@ -191,49 +182,81 @@ private class RecreateClaims(private val visitor: ClaimVisitor?) {
      * Replaces the direct (immediate) digests found in the _sd claim
      * with the [Disclosure.ObjectProperty.claim] from [disclosures]
      *
-     * @param disclosures the disclosures to use when replacing digests
-     * @param claims the claims to use
+     * @param jsonObject the claims to use
      * @param current the [JsonPointer] of the current element
      *
-     * @return the given [claims] with the digests, if any, replaced by disclosures.
+     * @return the given [jsonObject] with the digests, if any, replaced by disclosures.
      */
-    private fun replaceDirectDigests(
-        disclosures: DisclosurePerDigest,
-        claims: Claims,
+    private fun replaceObjectDigests(
         current: JsonPointer,
-    ): Claims {
-        val resultingClaims = claims.toMutableMap()
+        jsonObject: JsonObject,
+    ): JsonObject {
+        val resultingClaims = jsonObject.toMutableMap()
 
-        fun embed(digest: DisclosureDigest, disclosure: Disclosure.ObjectProperty) {
-            val (name, value) = disclosure.claim()
-            require(!claims.containsKey(name)) { "Failed to embed disclosure with key $name. Already present" }
-
-            visited(current.child(name), disclosure)
-
-            disclosures.remove(digest)
-            resultingClaims[name] = value
-        }
-
-        // Replace each digest with the claim from the disclosure, if found
-        // otherwise digest is probably decoy
-        for (digest in claims.directDigests()) {
+        fun replace(digest: DisclosureDigest) {
             disclosures[digest]?.let { disclosure ->
                 check(disclosure is Disclosure.ObjectProperty) {
                     "Found array element disclosure ${disclosure.value} within _sd claim"
                 }
-                embed(digest, disclosure)
+                val (name, value) = disclosure.claim()
+                require(!jsonObject.containsKey(name)) {
+                    "Failed to embed disclosure with key $name. Already present"
+                }
+                visited(current.child(name), disclosure)
+                disclosures.remove(digest)
+                resultingClaims[name] = value
             }
         }
+
+        // Replace each digest with the claim from the disclosure, if found
+        // otherwise digest is probably decoy
+        jsonObject.directDigests().forEach { replace(it) }
+
         // Remove _sd claim, if present
         resultingClaims.remove("_sd")
 
-        return resultingClaims
+        return JsonObject(resultingClaims)
+    }
+
+    //
+    // JSON Array
+    //
+
+    private fun discloseArray(
+        currentPointer: JsonPointer,
+        jsonArray: JsonArray,
+    ): JsonArray =
+        jsonArray
+            .zip(0..<jsonArray.size)
+            .mapNotNull { (element, index) -> discloseArrayElement(currentPointer, element, index) }
+            .let { elements -> JsonArray(elements) }
+
+    private fun discloseArrayElement(
+        currentPointer: JsonPointer,
+        arrayElement: JsonElement,
+        index: Int,
+    ): JsonElement? {
+        val elementPath = currentPointer.child(index)
+        val disclosedElement =
+            when (val disclosed = DisclosedArrayElement.of(arrayElement)) {
+                is DisclosedArrayElement.Digest -> {
+                    replaceArrayDigest(elementPath, disclosed.digest)
+                }
+
+                DisclosedArrayElement.Object -> {
+                    visited(elementPath, null)
+                    arrayElement
+                }
+
+                DisclosedArrayElement.NotAnObject -> arrayElement
+            }
+        return disclosedElement
+            ?.let { discloseElement(elementPath, it) }
     }
 
     private fun replaceArrayDigest(
-        disclosures: DisclosurePerDigest,
-        digest: DisclosureDigest,
         current: JsonPointer,
+        digest: DisclosureDigest,
     ): JsonElement? =
         disclosures[digest]?.let { disclosure ->
             check(disclosure is Disclosure.ArrayElement) {
@@ -263,6 +286,7 @@ private sealed interface DisclosedArrayElement {
                         null -> Object
                         else -> Digest(digest)
                     }
+
                 else -> NotAnObject
             }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SaltProvider.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SaltProvider.kt
@@ -15,7 +15,7 @@
  */
 package eu.europa.ec.eudi.sdjwt
 
-import kotlin.random.Random
+import java.security.SecureRandom
 
 /**
  * An interface for generating [Salt] values.
@@ -36,7 +36,7 @@ fun interface SaltProvider {
          */
         val Default: SaltProvider by lazy { randomSaltProvider(16) }
 
-        private val secureRandom: Random = Random.Default
+        private val secureRandom: SecureRandom = SecureRandom()
 
         /**
          * Creates a salt provider which generates random [Salt] values

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtFactory.kt
@@ -120,8 +120,11 @@ class SdJwtFactory(
 
         fun encodeSdArray(sdArray: SdArray): EncodedSdElement {
             val (disclosures, plainOrDigestElements) = arrayElementsDisclosure(sdArray)
+            val digestNumberHint = sdArray.digestNumberHint ?: globalDigestNumberHint ?: 0
+            val numOfDecoys = digestNumberHint - plainOrDigestElements.size
+            val decoys = decoyGen.gen(hashAlgorithm, numOfDecoys).map { PlainOrDigest.Dig(it) }
             val allElements = JsonArray(
-                plainOrDigestElements.map {
+                (plainOrDigestElements + decoys).map {
                     when (it) {
                         is PlainOrDigest.Dig -> it.value.asDigestClaim()
                         is PlainOrDigest.Plain -> it.value

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtFactory.kt
@@ -163,10 +163,6 @@ class SdJwtFactory(
         }
     }
 
-    private fun decoys() = decoyGen.genUpTo(hashAlgorithm, numOfDecoysLimit)
-    private fun Iterable<DisclosureDigest>.sorted(): Set<DisclosureDigest> =
-        toSortedSet(Comparator.comparing { it.value })
-
     /**
      * Adds the hash algorithm claim if disclosures are present
      * @param h the hash algorithm

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
@@ -43,9 +43,11 @@ internal class DecoyTest {
             return issuer.issue(spec).getOrThrow()
         }
 
-        val (simpleSdJwts, premiumSdJwts) = (1..100).map {
-            issue(simpleMembership) to issue(premiumMembership)
-        }.unzip()
+        val (simpleSdJwts, premiumSdJwts) =
+            (1..100)
+                .map { issue(simpleMembership) to issue(premiumMembership) }
+                .unzip()
+
         fun printFreq(s: String, f: Map<Int, Int>) {
             println("$s\t(DigestNo/Occurrences) $f")
         }
@@ -54,10 +56,12 @@ internal class DecoyTest {
         premiumSdJwts.digestFrequency().also { printFreq("premium", it) }
     }
 
-    fun Iterable<SdJwt.Issuance<SignedJWT>>.digestFrequency() =
-        map {
-            it.countDigests()
-        }.groupBy { it }.mapValues { (_, vs) -> vs.size }.toSortedMap()
+    private fun Iterable<SdJwt.Issuance<SignedJWT>>.digestFrequency() =
+        this
+            .map { it.countDigests() }
+            .groupBy { it }
+            .mapValues { (_, vs) -> vs.size }
+            .toSortedMap()
 
     // That's not safe, but it will do for them example
     // counts only top-level digests

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
@@ -67,7 +67,7 @@ internal class DecoyTest {
     // counts only top-level digests
     private fun SdJwt.Issuance<SignedJWT>.countDigests() = jwt.jwtClaimsSet.asClaims().directDigests().count()
 
-    private fun sdJwtSpec(membership: Membership) = sdJwt {
+    private fun sdJwtSpec(membership: Membership) = sdJwt(5) {
         sd("name", membership.name)
         if (membership is Membership.Premium) {
             sd("premiumMembershipNumber", membership.premiumMembershipNumber)

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
@@ -67,7 +67,7 @@ internal class DecoyTest {
     // counts only top-level digests
     private fun SdJwt.Issuance<SignedJWT>.countDigests() = jwt.jwtClaimsSet.asClaims().directDigests().count()
 
-    private fun sdJwtSpec(membership: Membership) = sdJwt(5) {
+    private fun sdJwtSpec(membership: Membership) = sdJwt(desiredDigests = 5) {
         sd("name", membership.name)
         if (membership is Membership.Premium) {
             sd("premiumMembershipNumber", membership.premiumMembershipNumber)

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.KeyUse
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator
+import com.nimbusds.jwt.SignedJWT
+import kotlin.test.Test
+
+sealed interface Membership {
+    val name: String
+
+    data class Simple(override val name: String) : Membership
+    data class Premium(override val name: String, val premiumMembershipNumber: String) : Membership
+}
+
+internal class DecoyTest {
+    private val simpleMembership = Membership.Simple(name = "Markus")
+    private val premiumMembership = Membership.Premium(name = "Markus", premiumMembershipNumber = "1234")
+
+    @Test
+    fun baseline() {
+        fun issue(m: Membership): SdJwt.Issuance<SignedJWT> {
+            val issuer = SampleIssuer.issuer()
+            val spec = sdJwtSpec(m)
+            return issuer.issue(spec).getOrThrow()
+        }
+
+        val (simpleSdJwts, premiumSdJwts) = (1..100).map {
+            issue(simpleMembership) to issue(premiumMembership)
+        }.unzip()
+        fun printFreq(s: String, f: Map<Int, Int>) {
+            println("$s\t(DigestNo/Occurrences) $f")
+        }
+
+        simpleSdJwts.digestFrequency().also { printFreq("simple", it) }
+        premiumSdJwts.digestFrequency().also { printFreq("premium", it) }
+    }
+
+    fun Iterable<SdJwt.Issuance<SignedJWT>>.digestFrequency() =
+        map {
+            it.countDigests()
+        }.groupBy { it }.mapValues { (_, vs) -> vs.size }.toSortedMap()
+
+    // That's not safe, but it will do for them example
+    // counts only top-level digests
+    private fun SdJwt.Issuance<SignedJWT>.countDigests() = jwt.jwtClaimsSet.asClaims().directDigests().count()
+
+    private fun sdJwtSpec(membership: Membership) = sdJwt {
+        sd("name", membership.name)
+        if (membership is Membership.Premium) {
+            sd("premiumMembershipNumber", membership.premiumMembershipNumber)
+        }
+    }
+}
+
+private object SampleIssuer {
+    const val KEY_ID = "signing-key-01"
+    private val alg = JWSAlgorithm.ES256
+    val key: ECKey = ECKeyGenerator(Curve.P_256)
+        .keyID(KEY_ID)
+        .keyUse(KeyUse.SIGNATURE)
+        .algorithm(alg)
+        .generate()
+    private val factory = SdJwtFactory(numOfDecoysLimit = 5)
+
+    fun issuer(): SdJwtIssuer<SignedJWT> =
+        SdJwtIssuer.nimbus(signer = ECDSASigner(key), signAlgorithm = alg, sdJwtFactory = factory)
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
@@ -67,7 +67,7 @@ internal class DecoyTest {
         val premiumMembershipSpec = premiumMembership.sdJwtSpec(null)
 
         val digestNumberHint = 5
-        val issuer = SampleIssuer(globalDigestNumberHint = digestNumberHint)
+        val issuer = SampleIssuer(globalMinDigests = digestNumberHint)
 
         assertEquals(digestNumberHint, issuer.issue(simpleMembershipSpec).countDigests())
         assertEquals(digestNumberHint, issuer.issue(premiumMembershipSpec).countDigests())
@@ -85,7 +85,7 @@ internal class DecoyTest {
     private fun SdJwt.Issuance<SignedJWT>.countDigests() = jwt.jwtClaimsSet.asClaims().directDigests().count()
 
     private fun Membership.sdJwtSpec(digestNumberHint: Int?) =
-        sdJwt(digestNumberHint = digestNumberHint) {
+        sdJwt(minimumDigests = digestNumberHint) {
             sd("name", name)
             if (this@sdJwtSpec is Membership.Premium) {
                 sd("premiumMembershipNumber", premiumMembershipNumber)
@@ -93,7 +93,7 @@ internal class DecoyTest {
         }
 }
 
-private class SampleIssuer(globalDigestNumberHint: Int? = null) {
+private class SampleIssuer(globalMinDigests: Int? = null) {
     val keyId = "signing-key-01"
     private val alg = JWSAlgorithm.ES256
     val key: ECKey = ECKeyGenerator(Curve.P_256)
@@ -106,7 +106,7 @@ private class SampleIssuer(globalDigestNumberHint: Int? = null) {
         SdJwtIssuer.nimbus(
             signer = ECDSASigner(key),
             signAlgorithm = alg,
-            sdJwtFactory = SdJwtFactory(globalDigestNumberHint = globalDigestNumberHint),
+            sdJwtFactory = SdJwtFactory(fallbackMinimumDigests = globalMinDigests?.let(::MinimumDigests)),
         )
 
     fun issue(sdElements: SdObject): SdJwt.Issuance<SignedJWT> =

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
@@ -39,9 +39,9 @@ internal class DecoyTest {
 
     @Test
     fun `make sure that kind membership is not revealed via digests number using hint on the spec`() {
-        val digestNumberHint = 5
-        val simpleMembershipSpec = simpleMembership.sdJwtSpec(digestNumberHint)
-        val premiumMembershipSpec = premiumMembership.sdJwtSpec(digestNumberHint)
+        val minimumDigests = 5
+        val simpleMembershipSpec = simpleMembership.sdJwtSpec(minimumDigests)
+        val premiumMembershipSpec = premiumMembership.sdJwtSpec(minimumDigests)
         val issuer = SampleIssuer()
         val (simpleSdJwts, premiumSdJwts) =
             (1..100)
@@ -66,11 +66,11 @@ internal class DecoyTest {
         val simpleMembershipSpec = simpleMembership.sdJwtSpec(null)
         val premiumMembershipSpec = premiumMembership.sdJwtSpec(null)
 
-        val digestNumberHint = 5
-        val issuer = SampleIssuer(globalMinDigests = digestNumberHint)
+        val minimumDigests = 5
+        val issuer = SampleIssuer(globalMinDigests = minimumDigests)
 
-        assertEquals(digestNumberHint, issuer.issue(simpleMembershipSpec).countDigests())
-        assertEquals(digestNumberHint, issuer.issue(premiumMembershipSpec).countDigests())
+        assertEquals(minimumDigests, issuer.issue(simpleMembershipSpec).countDigests())
+        assertEquals(minimumDigests, issuer.issue(premiumMembershipSpec).countDigests())
     }
 
     private fun Iterable<SdJwt.Issuance<SignedJWT>>.digestFrequency() =
@@ -84,8 +84,8 @@ internal class DecoyTest {
     // counts only top-level digests
     private fun SdJwt.Issuance<SignedJWT>.countDigests() = jwt.jwtClaimsSet.asClaims().directDigests().count()
 
-    private fun Membership.sdJwtSpec(digestNumberHint: Int?) =
-        sdJwt(minimumDigests = digestNumberHint) {
+    private fun Membership.sdJwtSpec(minimumDigests: Int?) =
+        sdJwt(minimumDigests) {
             sd("name", name)
             if (this@sdJwtSpec is Membership.Premium) {
                 sd("premiumMembershipNumber", premiumMembershipNumber)

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DisclosedClaimSetTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DisclosedClaimSetTest.kt
@@ -38,7 +38,7 @@ class DisclosedClaimSetTest {
                 },
             )
 
-            val sdJwtFactory = SdJwtFactory(numOfDecoysLimit = 0)
+            val sdJwtFactory = SdJwtFactory(globalDigestNumberHint = 0)
             invalidClaims.forEach { sdJwt ->
                 val result = sdJwtFactory.createSdJwt(sdJwt)
                 assertFalse { result.isSuccess }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DisclosedClaimSetTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DisclosedClaimSetTest.kt
@@ -38,7 +38,7 @@ class DisclosedClaimSetTest {
                 },
             )
 
-            val sdJwtFactory = SdJwtFactory(globalDigestNumberHint = 0)
+            val sdJwtFactory = SdJwtFactory.Default
             invalidClaims.forEach { sdJwt ->
                 val result = sdJwtFactory.createSdJwt(sdJwt)
                 assertFalse { result.isSuccess }
@@ -114,7 +114,7 @@ class DisclosedClaimSetTest {
                 hashAlgorithm,
                 SaltProvider.Default,
                 DecoyGen.Default,
-                4,
+                4.atLeastDigests(),
             ).createSdJwt(sdJwtElements).getOrThrow()
 
             val (jwtClaimSet, disclosures) = disclosedJsonObject
@@ -199,12 +199,11 @@ class DisclosedClaimSetTest {
                 plain(JsonObject(plainClaims))
                 claimsToBeDisclosed.forEach { c -> structured(c.key) { sd(c.value.jsonObject) } }
             }
-            val numOfDecoys = 0
             val disclosedJsonObject = SdJwtFactory(
                 hashAlgorithm,
                 SaltProvider.Default,
                 DecoyGen.Default,
-                numOfDecoys,
+                null,
 
             ).createSdJwt(sdJwtElements).getOrThrow()
 

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DisclosedClaimSetTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DisclosedClaimSetTest.kt
@@ -199,7 +199,7 @@ class DisclosedClaimSetTest {
                 plain(JsonObject(plainClaims))
                 claimsToBeDisclosed.forEach { c -> structured(c.key) { sd(c.value.jsonObject) } }
             }
-            val numOfDecoys = 4
+            val numOfDecoys = 0
             val disclosedJsonObject = SdJwtFactory(
                 hashAlgorithm,
                 SaltProvider.Default,

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVCIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVCIssuer.kt
@@ -130,7 +130,7 @@ class SdJwtVCIssuer(private val config: IssuerConfig) {
     private val issuer: SdJwtIssuer<SignedJWT> by lazy {
         // SD-JWT VC requires no decoys
 
-        val sdJwtFactory = SdJwtFactory(hashAlgorithm = config.hashAlgorithm, numOfDecoysLimit = 0)
+        val sdJwtFactory = SdJwtFactory(hashAlgorithm = config.hashAlgorithm, globalDigestNumberHint = 0)
         val signer = ECDSASigner(config.issuerKey)
         SdJwtIssuer.nimbus(sdJwtFactory, signer, config.signAlg) {
             // SD-JWT VC requires the kid & typ header attributes

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVCIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVCIssuer.kt
@@ -130,7 +130,7 @@ class SdJwtVCIssuer(private val config: IssuerConfig) {
     private val issuer: SdJwtIssuer<SignedJWT> by lazy {
         // SD-JWT VC requires no decoys
 
-        val sdJwtFactory = SdJwtFactory(hashAlgorithm = config.hashAlgorithm, globalDigestNumberHint = 0)
+        val sdJwtFactory = SdJwtFactory(hashAlgorithm = config.hashAlgorithm)
         val signer = ECDSASigner(config.issuerKey)
         SdJwtIssuer.nimbus(sdJwtFactory, signer, config.signAlg) {
             // SD-JWT VC requires the kid & typ header attributes

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Utils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Utils.kt
@@ -84,20 +84,13 @@ fun DisclosuresPerClaim.prettyPrint() {
 
 fun String.removeNewLine(): String = replace("\n", "")
 
-internal fun SdObject.assertThat(
-    description: String = "",
-    numOfDecoysLimit: Int = 0,
-    expectedDisclosuresNo: Int = 0,
-) {
+internal fun SdObject.assertThat(description: String = "", expectedDisclosuresNo: Int = 0) {
     println(description)
-    val sdJwtFactory = SdJwtFactory(numOfDecoysLimit = numOfDecoysLimit)
+    val sdJwtFactory = SdJwtFactory.Default
     val sdJwt = assertNotNull(sdJwtFactory.createSdJwt(this).getOrNull()).apply { prettyPrint { it } }
     assertEquals(expectedDisclosuresNo, sdJwt.disclosures.size)
     println("=====================================")
 }
-
-internal fun SdObject.assertThat(description: String = "", expectedDisclosuresNo: Int = 0) =
-    assertThat(description, 0, expectedDisclosuresNo)
 
 internal fun loadRsaKey(name: String): RSAKey = RSAKey.parse(loadResource(name))
 


### PR DESCRIPTION
This PR is in response of #199  and focuses on the following:

- Adds support for using decoy digests for selectively disclosable arrays (including recursively disclosable arrays)
- Replaces the way that decoys were added. Instead of randomly producing decoys, the control is now on the hands of the caller.
- Improves DSL by introducing an optional parameter which expresses the minimum number of digests (disclosure or decoy digests) the caller wants to be present. This feature is the solution to #199 


Other changes:
- Refactored `RecreateClaims` to lower code complexity and use better (function names) 
- Use SecureRandom to SaltProvider
- Add a new section to README providing details about the decoy-related changes in the DSL

Closes #199 
Closes #205 
Closes #206
