### PR TITLE
Add a method for parsing SdJwt.Issuance without verifying signature

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -181,6 +181,21 @@ fun NimbusJWTProcessor<*>.asJwtVerifier(): JwtSignatureVerifier = JwtSignatureVe
     process(unverifiedJwt, null).asClaims()
 }
 
+/**
+ * A method for obtaining an [SdJwt.Issuance] given an [unverifiedSdJwt], without checking the signature
+ * of the issuer.
+ *
+ * The method can be useful in case where a holder has previously [verified][SdJwtVerifier.verifyIssuance] the SD-JWT and
+ * wants to just re-obtain an instance of the [SdJwt.Issuance] without repeating this verification
+ *
+ */
+fun SdJwt.Companion.unverifiedIssuanceFrom(unverifiedSdJwt: String): Result<SdJwt.Issuance<JwtAndClaims>> = runCatching {
+    val (unverifiedJwt, unverifiedDisclosures) = parseIssuance(unverifiedSdJwt)
+    verifyIssuance(unverifiedJwt, unverifiedDisclosures) {
+        NimbusSignedJWT.parse(unverifiedJwt).jwtClaimsSet.asClaims()
+    }.getOrThrow()
+}
+
 //
 // JSON Support
 //

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Types.kt
@@ -116,4 +116,6 @@ sealed interface SdJwt<out JWT> {
         override val jwt: JWT,
         override val disclosures: List<Disclosure>,
     ) : SdJwt<JWT>
+
+    companion object
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyIssuanceTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.fail
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -73,9 +74,14 @@ class SdJwtVerifierVerifyIssuanceTest {
         jwtSignatureVerifier: JwtSignatureVerifier,
         unverifiedSdJwt: String,
     ) {
-        val verification =
-            SdJwtVerifier.verifyIssuance(jwtSignatureVerifier = jwtSignatureVerifier, unverifiedSdJwt = unverifiedSdJwt)
-        assertTrue { verification.isSuccess }
+        val verifiedSdJwt = assertDoesNotThrow {
+            SdJwtVerifier.verifyIssuance(jwtSignatureVerifier = jwtSignatureVerifier, unverifiedSdJwt = unverifiedSdJwt).getOrThrow()
+        }
+
+        val sdJwtWithOutSigVerification = assertDoesNotThrow {
+            SdJwt.unverifiedIssuanceFrom(unverifiedSdJwt).getOrThrow()
+        }
+        assertEquals(verifiedSdJwt, sdJwtWithOutSigVerification)
     }
 
     private fun unverifiedSdJwtJWSJson(option: JwsSerializationOption): JsonObject {


### PR DESCRIPTION
Closes #200 

PR implements the approach described [here](https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-sdjwt-kt/pull/201#pullrequestreview-2141122122)