### PR TITLE
Update JWS JSON support

### DIFF
--- a/Module.md
+++ b/Module.md
@@ -3,7 +3,7 @@
 `eudi-lib-jvm-sdjwt-kt` offers a DSL (domain-specific language) for defining how a set of claims should be made selectively
 disclosable.
 
-Library implements [SD-JWT draft 8](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-08.html)
+Library implements [SD-JWT draft 12](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-12.html)
 is implemented in Kotlin, targeting JVM.
 
 Library's SD-JWT DSL leverages the DSL provided by

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the [EUDI Wallet Reference Implementation project description](https://github.co
 This is a library offering a DSL (domain-specific language) for defining how a set of claims should be made selectively
 disclosable.
 
-Library implements [SD-JWT draft 8](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-08.html)
+Library implements [SD-JWT draft 12](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-12.html)
 is implemented in Kotlin, targeting JVM.
 
 Library's SD-JWT DSL leverages the DSL provided by

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ should be left outside the scope of this library.
 
 ## Presentation Verification
 
-### In simple (not enveloped) format
+### In simple format
 
 In this case, the SD-JWT is expected to be in Combined Presentation format.
 Verifier should know the public key of the Issuer and the algorithm used by the Issuer
@@ -224,6 +224,11 @@ val verifiedPresentationSdJwt: SdJwt.Presentation<JwtAndClaims> = runBlocking {
 ```
 
 > You can get the full code [here](src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExamplePresentationSdJwtVerification01.kt).
+
+Library provides various variants of the above method that:
+
+- Preserve the KB-JWT, if present, to the successful outcome of a verification
+- Accept the unverified SD-JWT serialized in JWS JSON  
 
 <!--- TEST verifiedPresentationSdJwt.prettyPrint { it.second } -->
 

--- a/README.md
+++ b/README.md
@@ -215,11 +215,12 @@ val verifiedPresentationSdJwt: SdJwt.Presentation<JwtAndClaims> = runBlocking {
     val jwtSignatureVerifier = RSASSAVerifier(issuerKeyPair).asJwtVerifier()
 
     val unverifiedPresentationSdJwt = loadSdJwt("/examplePresentationSdJwt.txt")
-    SdJwtVerifier.verifyPresentation(
+    val (sdJwt, _) = SdJwtVerifier.verifyPresentation(
         jwtSignatureVerifier = jwtSignatureVerifier,
         keyBindingVerifier = KeyBindingVerifier.MustNotBePresent,
         unverifiedSdJwt = unverifiedPresentationSdJwt,
     ).getOrThrow()
+    sdJwt
 }
 ```
 

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -357,7 +357,27 @@ fun <JWT : NimbusJWT> SdJwt.Presentation<JWT>.serializeWithKeyBinding(
     hashAlgorithm: HashAlgorithm,
     keyBindingSigner: KeyBindingSigner,
     claimSetBuilderAction: JWTClaimsSet.Builder.() -> Unit,
-): String = serializeWithKeyBinding(NimbusJWT::serialize, hashAlgorithm, keyBindingSigner, claimSetBuilderAction)
+): String =
+    serializeWithKeyBinding(NimbusJWT::serialize, hashAlgorithm, keyBindingSigner, claimSetBuilderAction)
+
+/**
+ * Serializes a [SdJwt.Presentation] with a Key Binding JWT  in JWS JSON
+ *
+ * @param hashAlgorithm [HashAlgorithm] to be used for generating the [SdJwtDigest] that will be included
+ * in the generated Key Binding JWT
+ * @param keyBindingSigner function used to sign the generated Key Binding JWT
+ * @param claimSetBuilderAction a function that can be used to further customize the claims
+ * of the generated Key Binding JWT.
+ * @param JWT the type representing the JWT part of the SD-JWT
+ * @receiver the SD-JWT to be serialized
+ * @return the serialized SD-JWT including the generated Key Binding JWT
+ */
+fun <JWT : NimbusJWT> SdJwt.Presentation<JWT>.serializeWithKeyBindingAsJwsJson(
+    hashAlgorithm: HashAlgorithm,
+    keyBindingSigner: KeyBindingSigner,
+    claimSetBuilderAction: JWTClaimsSet.Builder.() -> Unit,
+): JsonObject =
+    serializeWithKeyBindingAsJwsJson(NimbusJWT::serialize, hashAlgorithm, keyBindingSigner, claimSetBuilderAction)
 
 /**
  * Serializes a [SdJwt.Presentation] with a Key Binding JWT.
@@ -401,7 +421,7 @@ fun <JWT> SdJwt.Presentation<JWT>.serializeWithKeyBinding(
  * @receiver the SD-JWT to be serialized
  * @return a pair of the serialized SD-JWT and the generated Key Binding JWT
  */
-fun <JWT> SdJwt.Presentation<JWT>.serializedAndKeyBinding(
+internal fun <JWT> SdJwt.Presentation<JWT>.serializedAndKeyBinding(
     jwtSerializer: (JWT) -> String,
     hashAlgorithm: HashAlgorithm,
     keyBindingSigner: KeyBindingSigner,
@@ -487,7 +507,7 @@ fun <JWT> SdJwt.Presentation<JWT>.serializeWithKeyBindingAsJwsJson(
  * @return a JSON object either general or flattened according to RFC7515 having an additional
  * disclosures array as per SD-JWT extension
  */
-fun SdJwt<NimbusSignedJWT>.serializeAsJwsJsonObject(
+fun SdJwt<NimbusSignedJWT>.serializeAsJwsJson(
     option: JwsSerializationOption = JwsSerializationOption.Flattened,
 ): JsonObject {
     return asJwsJsonObject(option, kbJwt = null) { jwt ->

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -191,7 +191,7 @@ fun NimbusJWTProcessor<*>.asJwtVerifier(): JwtSignatureVerifier = JwtSignatureVe
  */
 fun SdJwt.Companion.unverifiedIssuanceFrom(unverifiedSdJwt: String): Result<SdJwt.Issuance<JwtAndClaims>> =
     runCatching {
-        val (unverifiedJwt, unverifiedDisclosures) = parseIssuance(unverifiedSdJwt)
+        val (unverifiedJwt, unverifiedDisclosures) = StandardSerialization.parseIssuance(unverifiedSdJwt)
         verifyIssuance(unverifiedJwt, unverifiedDisclosures) {
             NimbusSignedJWT.parse(unverifiedJwt).jwtClaimsSet.asClaims()
         }.getOrThrow()

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtSerialization.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtSerialization.kt
@@ -52,28 +52,27 @@ enum class JwsSerializationOption {
 /**
  * Creates a representation of an [SdJwt] as a JWS JSON according to RFC7515.
  * In addition to the General & Flattened representations defined in the RFC7515,
- * the result JSON contains a JSON array with the disclosures of the [SdJwt]
+ *  the result JSON contains an unprotected header which includes
+ *  an array with the disclosures of the [SdJwt] and optionally the key binding JWT
  *
- * Please note that this serialization option cannot be used to convey the key binding JWT
- * of a [SdJwt.Presentation]
- *
+ * @param option to produce a [JwsSerializationOption.General] or [JwsSerializationOption.Flattened]
+ *   representation as defined in RFC7515
+ * @param kbJwt the key binding JWT for the SD-JWT.
  * @param getParts a function to extract out of the [jwt][SdJwt.jwt]  of the SD-JWT
  * the three JWS parts: protected header, payload and signature.
  * Each part is base64 encoded
- *
- * @param option to produce a [JwsSerializationOption.General] or [JwsSerializationOption.Flattened]
- * representation as defined in RFC7515
  * @receiver the [SdJwt] to serialize
  *
  * @return a JSON object either general or flattened according to RFC7515 having an additional
- * disclosures array as per SD-JWT extension
+ * disclosures array and possibly the KB-JWT in an unprotected header as per SD-JWT extension
  */
 fun <JWT> SdJwt<JWT>.asJwsJsonObject(
     option: JwsSerializationOption = JwsSerializationOption.Flattened,
+    kbJwt: Jwt?,
     getParts: (JWT) -> Triple<String, String, String>,
 ): JsonObject {
     val (protected, payload, signature) = getParts(jwt)
-    return option.jwsJsonObject(protected, payload, signature, disclosures.map { it.value }.toSet())
+    return option.jwsJsonObject(protected, payload, signature, disclosures.map { it.value }.toSet(), kbJwt)
 }
 
 internal fun JwsSerializationOption.jwsJsonObject(
@@ -81,21 +80,36 @@ internal fun JwsSerializationOption.jwsJsonObject(
     payload: String,
     signature: String,
     disclosures: Set<String>,
+    kbJwt: Jwt?,
 ): JsonObject {
-    fun JsonObjectBuilder.putProtectedAndSignature() {
-        put("protected", protected)
-        put("signature", signature)
-    }
-    return buildJsonObject {
-        put("payload", payload)
-        when (this@jwsJsonObject) {
-            JwsSerializationOption.General -> {
-                val element = buildJsonObject { putProtectedAndSignature() }
-                put("signatures", JsonArray(listOf(element)))
+    fun JsonObjectBuilder.putHeadersAndSignature() {
+        putJsonObject(JWS_JSON_HEADER) {
+            put(JWS_JSON_DISCLOSURES, JsonArray(disclosures.map { JsonPrimitive(it) }))
+            if (kbJwt != null) {
+                put(JWS_JSON_KB_JWT, kbJwt)
             }
-
-            JwsSerializationOption.Flattened -> putProtectedAndSignature()
         }
-        put("disclosures", JsonArray(disclosures.map { JsonPrimitive(it) }))
+        put(JWS_JSON_PROTECTED, protected)
+        put(JWS_JSON_SIGNATURE, signature)
+    }
+
+    return buildJsonObject {
+        put(JWS_JSON_PAYLOAD, payload)
+        when (this@jwsJsonObject) {
+            JwsSerializationOption.General ->
+                putJsonArray(JWS_JSON_SIGNATURES) {
+                    add(buildJsonObject { putHeadersAndSignature() })
+                }
+
+            JwsSerializationOption.Flattened -> putHeadersAndSignature()
+        }
     }
 }
+
+private const val JWS_JSON_HEADER = "header"
+private const val JWS_JSON_DISCLOSURES = "disclosures"
+private const val JWS_JSON_KB_JWT = "kb_jwt"
+private const val JWS_JSON_PROTECTED = "protected"
+private const val JWS_JSON_SIGNATURE = "signature"
+private const val JWS_JSON_SIGNATURES = "signatures"
+private const val JWS_JSON_PAYLOAD = "payload"

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
@@ -328,7 +328,7 @@ object SdJwtVerifier {
      * are representing in both string and decoded payload.
      * Expected errors are reported via a [SdJwtVerificationException]
      */
-    suspend fun verifyPresentationKeepingKbJwt(
+    suspend fun verifyPresentation(
         jwtSignatureVerifier: JwtSignatureVerifier,
         keyBindingVerifier: KeyBindingVerifier,
         unverifiedSdJwt: String,
@@ -370,38 +370,16 @@ object SdJwtVerifier {
      * are representing in both string and decoded payload.
      * Expected errors are reported via a [SdJwtVerificationException]
      */
-    suspend fun verifyPresentationKeepingKbJwt(
+    suspend fun verifyPresentation(
         jwtSignatureVerifier: JwtSignatureVerifier,
         keyBindingVerifier: KeyBindingVerifier,
         unverifiedSdJwt: JsonObject,
     ): Result<Pair<SdJwt.Presentation<JwtAndClaims>, JwtAndClaims?>> = runCatching {
         // Parse and re-assemble it in combined form
         val unverifiedSdJwtAsString = JwsJsonSupport.parseIntoStandardForm(unverifiedSdJwt)
-        verifyPresentationKeepingKbJwt(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwtAsString).getOrThrow()
+        verifyPresentation(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwtAsString).getOrThrow()
     }
 }
-
-/**
- * Convenient method that performs the verification [SdJwtVerifier.verifyPresentationKeepKbJwt]
- * and discards key binding JWT
- */
-suspend fun SdJwtVerifier.verifyPresentation(
-    jwtSignatureVerifier: JwtSignatureVerifier,
-    keyBindingVerifier: KeyBindingVerifier,
-    unverifiedSdJwt: String,
-): Result<SdJwt.Presentation<JwtAndClaims>> =
-    verifyPresentationKeepingKbJwt(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt).map { it.first }
-
-/**
- * Convenient method that performs the verification [SdJwtVerifier.verifyPresentationKeepKbJwt]
- * and discards key binding JWT
- */
-suspend fun SdJwtVerifier.verifyPresentation(
-    jwtSignatureVerifier: JwtSignatureVerifier,
-    keyBindingVerifier: KeyBindingVerifier,
-    unverifiedSdJwt: JsonObject,
-): Result<SdJwt.Presentation<JwtAndClaims>> =
-    verifyPresentationKeepingKbJwt(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt).map { it.first }
 
 internal fun verifyIssuance(
     unverifiedJwt: Jwt,
@@ -543,7 +521,7 @@ object ClaimValidations {
 
     /**
      * Retrieves the iat claim, if present and within the provided time window.
-     * The time window will be calculated by obtaining the [current time][Clock.instant]
+     * The time window will be calculated by getting the [current time][Clock.instant]
      * and the [offset].
      * That is, iat less than equal to the clock's current time and not before the current time minus the offset
      *

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
@@ -328,7 +328,7 @@ object SdJwtVerifier {
      * are representing in both string and decoded payload.
      * Expected errors are reported via a [SdJwtVerificationException]
      */
-    suspend fun verifyPresentationKeepKbJwt(
+    suspend fun verifyPresentationKeepingKbJwt(
         jwtSignatureVerifier: JwtSignatureVerifier,
         keyBindingVerifier: KeyBindingVerifier,
         unverifiedSdJwt: String,
@@ -370,14 +370,14 @@ object SdJwtVerifier {
      * are representing in both string and decoded payload.
      * Expected errors are reported via a [SdJwtVerificationException]
      */
-    suspend fun verifyPresentationKeepKbJwt(
+    suspend fun verifyPresentationKeepingKbJwt(
         jwtSignatureVerifier: JwtSignatureVerifier,
         keyBindingVerifier: KeyBindingVerifier,
         unverifiedSdJwt: JsonObject,
     ): Result<Pair<SdJwt.Presentation<JwtAndClaims>, JwtAndClaims?>> = runCatching {
         // Parse and re-assemble it in combined form
         val unverifiedSdJwtAsString = JwsJsonSupport.parseIntoStandardForm(unverifiedSdJwt)
-        verifyPresentationKeepKbJwt(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwtAsString).getOrThrow()
+        verifyPresentationKeepingKbJwt(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwtAsString).getOrThrow()
     }
 }
 
@@ -390,7 +390,7 @@ suspend fun SdJwtVerifier.verifyPresentation(
     keyBindingVerifier: KeyBindingVerifier,
     unverifiedSdJwt: String,
 ): Result<SdJwt.Presentation<JwtAndClaims>> =
-    verifyPresentationKeepKbJwt(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt).map { it.first }
+    verifyPresentationKeepingKbJwt(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt).map { it.first }
 
 /**
  * Convenient method that performs the verification [SdJwtVerifier.verifyPresentationKeepKbJwt]
@@ -401,7 +401,7 @@ suspend fun SdJwtVerifier.verifyPresentation(
     keyBindingVerifier: KeyBindingVerifier,
     unverifiedSdJwt: JsonObject,
 ): Result<SdJwt.Presentation<JwtAndClaims>> =
-    verifyPresentationKeepKbJwt(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt).map { it.first }
+    verifyPresentationKeepingKbJwt(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt).map { it.first }
 
 internal fun verifyIssuance(
     unverifiedJwt: Jwt,

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -119,13 +119,13 @@ class SdJwtVcVerifier(
      * are representing in both string and decoded payload.
      * Expected errors are reported via a [SdJwtVerificationException]
      */
-    suspend fun verifyPresentationKeepingKbJwt(
+    suspend fun verifyPresentation(
         unverifiedSdJwt: String,
         challenge: JsonObject? = null,
     ): Result<Pair<SdJwt.Presentation<JwtAndClaims>, JwtAndClaims?>> = coroutineScope {
         val jwtSignatureVerifier = async { jwtSignatureVerifier() }
         val keyBindingVerifier = KeyBindingVerifier.forSdJwtVc(challenge)
-        SdJwtVerifier.verifyPresentationKeepingKbJwt(jwtSignatureVerifier.await(), keyBindingVerifier, unverifiedSdJwt)
+        SdJwtVerifier.verifyPresentation(jwtSignatureVerifier.await(), keyBindingVerifier, unverifiedSdJwt)
     }
 
     /**
@@ -139,30 +139,18 @@ class SdJwtVcVerifier(
      * are representing in both string and decoded payload.
      * Expected errors are reported via a [SdJwtVerificationException]
      */
-    suspend fun verifyPresentationKeepingKbJwt(
+    suspend fun verifyPresentation(
         unverifiedSdJwt: JsonObject,
         challenge: JsonObject? = null,
     ): Result<Pair<SdJwt.Presentation<JwtAndClaims>, JwtAndClaims?>> = coroutineScope {
         val jwtSignatureVerifier = async { jwtSignatureVerifier() }
         val keyBindingVerifier = KeyBindingVerifier.forSdJwtVc(challenge)
-        SdJwtVerifier.verifyPresentationKeepingKbJwt(jwtSignatureVerifier.await(), keyBindingVerifier, unverifiedSdJwt)
+        SdJwtVerifier.verifyPresentation(jwtSignatureVerifier.await(), keyBindingVerifier, unverifiedSdJwt)
     }
 
     private fun jwtSignatureVerifier(): JwtSignatureVerifier =
         sdJwtVcSignatureVerifier(httpClientFactory, trust, lookup)
 }
-
-suspend fun SdJwtVcVerifier.verifyPresentation(
-    unverifiedSdJwt: String,
-    challenge: JsonObject? = null,
-): Result<SdJwt.Presentation<JwtAndClaims>> =
-    verifyPresentationKeepingKbJwt(unverifiedSdJwt, challenge).map { it.first }
-
-suspend fun SdJwtVcVerifier.verifyPresentation(
-    unverifiedSdJwt: JsonObject,
-    challenge: JsonObject? = null,
-): Result<SdJwt.Presentation<JwtAndClaims>> =
-    verifyPresentationKeepingKbJwt(unverifiedSdJwt, challenge).map { it.first }
 
 fun KeyBindingVerifier.Companion.forSdJwtVc(challenge: JsonObject?): KeyBindingVerifier.MustBePresentAndValid =
     KeyBindingVerifier.mustBePresentAndValid(HolderPubKeyInConfirmationClaim, challenge)
@@ -278,6 +266,7 @@ internal fun keySource(jwt: SignedJWT): SdJwtVcIssuerPublicKeySource? {
             if (leaf.containsIssuerUri(issUrl) || leaf.containsIssuerDnsName(issUrl)) X509CertChain(issUrl, certChain)
             else null
         }
+
         issScheme == DID_URI_SCHEME && certChain.isEmpty() -> DIDUrl(iss, kid)
         else -> null
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/JwsJsonSerialization.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/JwsJsonSerialization.kt
@@ -100,7 +100,7 @@ class JwsJsonSerialization {
         val trObj = TrObj.parse(ex1)
         val sdJwt: SdJwt.Issuance<SignedJWT> = SdJwt.Issuance(trObj.jwt, trObj.disclosures)
         val actual =
-            sdJwt.serializeAsJwsJsonObject(option = JwsSerializationOption.Flattened).also { println(json.encodeToString(it)) }
+            sdJwt.serializeAsJwsJson(option = JwsSerializationOption.Flattened).also { println(json.encodeToString(it)) }
         assertEquals(json.parseToJsonElement(ex1), actual)
     }
 
@@ -120,7 +120,7 @@ class JwsJsonSerialization {
         val sdJwt = assertDoesNotThrow { issuer.issue(sdJwtSpec).getOrThrow() }
 
         assertDoesNotThrow {
-            sdJwt.serializeAsJwsJsonObject(option = JwsSerializationOption.Flattened).also { println(json.encodeToString(it)) }
+            sdJwt.serializeAsJwsJson(option = JwsSerializationOption.Flattened).also { println(json.encodeToString(it)) }
         }
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -308,8 +308,9 @@ class VerifierActor(
     suspend fun acceptPresentation(
         unverifiedSdJwt: String,
     ) {
-        val presented = verifier.verifyPresentation(unverifiedSdJwt, lastChallenge).getOrThrow().ensureContainsWhatRequested()
-        presentation = presented
+        val (presented, _) =
+            verifier.verifyPresentationKeepingKbJwt(unverifiedSdJwt, lastChallenge).getOrThrow()
+        presentation = presented.ensureContainsWhatRequested()
         verifierDebug("Presentation accepted with SD Claims:")
     }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -309,7 +309,7 @@ class VerifierActor(
         unverifiedSdJwt: String,
     ) {
         val (presented, _) =
-            verifier.verifyPresentationKeepingKbJwt(unverifiedSdJwt, lastChallenge).getOrThrow()
+            verifier.verifyPresentation(unverifiedSdJwt, lastChallenge).getOrThrow()
         presentation = presented.ensureContainsWhatRequested()
         verifierDebug("Presentation accepted with SD Claims:")
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyIssuanceTest.kt
@@ -98,7 +98,7 @@ class SdJwtVerifierVerifyIssuanceTest {
             wYeE4ISu3DQkOk7VeaMMYB73Hsdyjal6e9FS
         """.trimIndent().removeNewLine()
 
-        return option.jwsJsonObject(protected, payload, signature, setOf(d1))
+        return option.jwsJsonObject(protected, payload, signature, setOf(d1), kbJwt = null)
     }
 
     private val jwt = """

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyIssuanceTest.kt
@@ -99,7 +99,9 @@ class SdJwtVerifierVerifyIssuanceTest {
             wYeE4ISu3DQkOk7VeaMMYB73Hsdyjal6e9FS
         """.trimIndent().removeNewLine()
 
-        return option.jwsJsonObject(protected, payload, signature, setOf(d1), kbJwt = null)
+        return with(JwsJsonSupport) {
+            option.buildJwsJson(protected, payload, signature, setOf(d1), kbJwt = null)
+        }
     }
 
     private val jwt = """

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyIssuanceTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.fail
 import kotlin.test.Test
@@ -223,8 +224,10 @@ class SdJwtVerifierVerifyIssuanceTest {
     @Test
     fun `when sd-jwt has an valid jwt, invalid disclosures verify should return InvalidDisclosures`() = runTest {
         val unverifiedSdJwt = unverifiedSdJwtJWSJson(JwsSerializationOption.Flattened).run {
+            val mutableHeader = checkNotNull(this["header"]).jsonObject.toMutableMap()
+            mutableHeader["disclosures"] = JsonArray(listOf("d1", "d2").map { JsonPrimitive(it) })
             val mutable = toMutableMap()
-            mutable["disclosures"] = JsonArray(listOf("d1", "d2").map { JsonPrimitive(it) })
+            mutable["header"] = JsonObject(mutableHeader)
             JsonObject(mutable)
         }
         verifyIssuanceExpectingError(
@@ -255,8 +258,10 @@ class SdJwtVerifierVerifyIssuanceTest {
     @Test
     fun `when sd-jwt has an valid jwt, non unique disclosures verify should return NonUnqueDisclosures`() = runTest {
         val unverifiedSdJwt = unverifiedSdJwtJWSJson(JwsSerializationOption.Flattened).run {
+            val mutableHeader = checkNotNull(this["header"]).jsonObject.toMutableMap()
+            mutableHeader["disclosures"] = JsonArray(listOf(d1, d1).map { JsonPrimitive(it) })
             val mutable = toMutableMap()
-            mutable["disclosures"] = JsonArray(listOf(d1, d1).map { JsonPrimitive(it) })
+            mutable["header"] = JsonObject(mutableHeader)
             JsonObject(mutable)
         }
         verifyIssuanceExpectingError(

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyPresentationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyPresentationTest.kt
@@ -16,6 +16,9 @@
 package eu.europa.ec.eudi.sdjwt
 
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -167,6 +170,24 @@ class SdJwtVerifierVerifyPresentationTest {
             )
         }
 
+    @Test
+    fun `happy path with sd-jwt with kb-jwt in JWS JSON`() = runTest {
+        verifySuccess(
+            JwtSignatureVerifier.NoSignatureValidation,
+            KeyBindingVerifier.MustBePresent,
+            Json.parseToJsonElement(ex2).jsonObject,
+        )
+    }
+
+    @Test
+    fun `happy path with sd-jwt without kb-jwt in JWS JSON`() = runTest {
+        verifySuccess(
+            JwtSignatureVerifier.NoSignatureValidation,
+            KeyBindingVerifier.MustNotBePresent,
+            Json.parseToJsonElement(ex3).jsonObject,
+        )
+    }
+
     private suspend fun verifyPresnetationExpectingError(
         expectedError: VerificationError,
         jwtSignatureVerifier: JwtSignatureVerifier,
@@ -187,6 +208,16 @@ class SdJwtVerifierVerifyPresentationTest {
         jwtSignatureVerifier: JwtSignatureVerifier,
         keyBindingVerifier: KeyBindingVerifier,
         unverifiedSdJwt: String,
+    ) {
+        val verification =
+            SdJwtVerifier.verifyPresentation(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt)
+        assertTrue { verification.isSuccess }
+    }
+
+    private suspend fun verifySuccess(
+        jwtSignatureVerifier: JwtSignatureVerifier,
+        keyBindingVerifier: KeyBindingVerifier,
+        unverifiedSdJwt: JsonObject,
     ) {
         val verification =
             SdJwtVerifier.verifyPresentation(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt)
@@ -221,3 +252,32 @@ class SdJwtVerifierVerifyPresentationTest {
             VrKEsvpb1Pe3fK7v5Ygh4gRL4zCR6QVm6VqzxdiZ67m0Hg
     """.trimIndent().removeNewLine()
 }
+
+private val ex2 = """
+    {
+      "header": {
+        "disclosures": [
+          "WyI2SWo3dE0tYTVpVlBHYm9TNXRtdlZBIiwgImZhbWlseV9uYW1lIiwgIkRvZSJd",
+          "WyJlbHVWNU9nM2dTTklJOEVZbnN4QV9BIiwgImdpdmVuX25hbWUiLCAiSm9obiJd"
+        ],
+        "kb_jwt": "eyJhbGciOiAiRVMyNTYiLCAidHlwIjogImtiK2p3dCJ9.eyJub25jZSI6ICIxMjM0NTY3ODkwIiwgImF1ZCI6ICJodHRwczovL3ZlcmlmaWVyLmV4YW1wbGUub3JnIiwgImlhdCI6IDE3MjUzNzQ0MTMsICJzZF9oYXNoIjogImQ5T3pJclJQY2dVanNKb3NzeVJ3SjZNOXo5TGpneGQtWmk3VmJfNGxveXMifQ.KEni_tu4WRFeH7croigMQu2u0Xy3dsUf7bmmDT8Q5yTg_xFh7kMxbWemFglmFUVrwqxdLHvXNuiKguF3TztL9Q"
+      },
+      "payload": "eyJfc2QiOiBbIjRIQm42YUlZM1d0dUdHV1R4LXFVajZjZGs2V0JwWnlnbHRkRmF2UGE3TFkiLCAiOHNtMVFDZjAyMXBObkhBQ0k1c1A0bTRLWmd5Tk9PQVljVGo5SE5hQzF3WSIsICJjZ0ZkaHFQbzgzeFlObEpmYWNhQ2FhN3VQOVJDUjUwVkU1UjRMQVE5aXFVIiwgImpNQ1hWei0tOWI4eDM3WWNvRGZYUWluencxd1pjY2NmRlJCQ0ZHcWRHMm8iXSwgImlzcyI6ICJodHRwczovL2lzc3Vlci5leGFtcGxlLmNvbSIsICJpYXQiOiAxNjgzMDAwMDAwLCAiZXhwIjogMTg4MzAwMDAwMCwgIl9zZF9hbGciOiAic2hhLTI1NiIsICJjbmYiOiB7Imp3ayI6IHsia3R5IjogIkVDIiwgImNydiI6ICJQLTI1NiIsICJ4IjogIlRDQUVSMTladnUzT0hGNGo0VzR2ZlNWb0hJUDFJTGlsRGxzN3ZDZUdlbWMiLCAieSI6ICJaeGppV1diWk1RR0hWV0tWUTRoYlNJaXJzVmZ1ZWNDRTZ0NGpUOUYySFpRIn19fQ",
+      "protected": "eyJhbGciOiAiRVMyNTYiLCAidHlwIjogImV4YW1wbGUrc2Qtand0In0",
+      "signature": "QqT_REPTOaBX4EzA9rQqad_iOL6pMl9_onmFH_q-Npyqal5TsxcUc5FIKjQL9BFO8QvA0BFbVbzaO-NLonN3Mw"
+    }
+""".trimIndent()
+
+private val ex3 = """
+    {
+      "header": {
+        "disclosures": [
+          "WyI2SWo3dE0tYTVpVlBHYm9TNXRtdlZBIiwgImZhbWlseV9uYW1lIiwgIkRvZSJd",
+          "WyJlbHVWNU9nM2dTTklJOEVZbnN4QV9BIiwgImdpdmVuX25hbWUiLCAiSm9obiJd"
+        ]
+      },
+      "payload": "eyJfc2QiOiBbIjRIQm42YUlZM1d0dUdHV1R4LXFVajZjZGs2V0JwWnlnbHRkRmF2UGE3TFkiLCAiOHNtMVFDZjAyMXBObkhBQ0k1c1A0bTRLWmd5Tk9PQVljVGo5SE5hQzF3WSIsICJjZ0ZkaHFQbzgzeFlObEpmYWNhQ2FhN3VQOVJDUjUwVkU1UjRMQVE5aXFVIiwgImpNQ1hWei0tOWI4eDM3WWNvRGZYUWluencxd1pjY2NmRlJCQ0ZHcWRHMm8iXSwgImlzcyI6ICJodHRwczovL2lzc3Vlci5leGFtcGxlLmNvbSIsICJpYXQiOiAxNjgzMDAwMDAwLCAiZXhwIjogMTg4MzAwMDAwMCwgIl9zZF9hbGciOiAic2hhLTI1NiIsICJjbmYiOiB7Imp3ayI6IHsia3R5IjogIkVDIiwgImNydiI6ICJQLTI1NiIsICJ4IjogIlRDQUVSMTladnUzT0hGNGo0VzR2ZlNWb0hJUDFJTGlsRGxzN3ZDZUdlbWMiLCAieSI6ICJaeGppV1diWk1RR0hWV0tWUTRoYlNJaXJzVmZ1ZWNDRTZ0NGpUOUYySFpRIn19fQ",
+      "protected": "eyJhbGciOiAiRVMyNTYiLCAidHlwIjogImV4YW1wbGUrc2Qtand0In0",
+      "signature": "QqT_REPTOaBX4EzA9rQqad_iOL6pMl9_onmFH_q-Npyqal5TsxcUc5FIKjQL9BFO8QvA0BFbVbzaO-NLonN3Mw"
+    }
+""".trimIndent()

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SpecExamples.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SpecExamples.kt
@@ -61,7 +61,7 @@ class SpecExamples {
                 KeyBindingVerifier.MustNotBePresent,
                 unverifiedSdJwt,
             ).getOrThrow()
-        }.also { it.printRecreated() }
+        }.also { (sdJwt, _) -> sdJwt.printRecreated() }
     }
 
     @Test
@@ -97,7 +97,7 @@ class SpecExamples {
                 KeyBindingVerifier.MustNotBePresent,
                 unverifiedSdJwt,
             ).getOrThrow()
-        }.also { it.printRecreated() }
+        }.also { (sdJwt, _) -> sdJwt.printRecreated() }
     }
 
     @Test
@@ -140,7 +140,7 @@ class SpecExamples {
                 KeyBindingVerifier.MustNotBePresent,
                 unverifiedSdJwt,
             ).getOrThrow()
-        }.also { it.printRecreated() }
+        }.also { (sdJwt, _) -> sdJwt.printRecreated() }
     }
 
     private fun SdJwt.Presentation<JwtAndClaims>.printRecreated() {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExamplePresentationSdJwtVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExamplePresentationSdJwtVerification01.kt
@@ -24,9 +24,10 @@ val verifiedPresentationSdJwt: SdJwt.Presentation<JwtAndClaims> = runBlocking {
     val jwtSignatureVerifier = RSASSAVerifier(issuerKeyPair).asJwtVerifier()
 
     val unverifiedPresentationSdJwt = loadSdJwt("/examplePresentationSdJwt.txt")
-    SdJwtVerifier.verifyPresentation(
+    val (sdJwt, _) = SdJwtVerifier.verifyPresentation(
         jwtSignatureVerifier = jwtSignatureVerifier,
         keyBindingVerifier = KeyBindingVerifier.MustNotBePresent,
         unverifiedSdJwt = unverifiedPresentationSdJwt,
     ).getOrThrow()
+    sdJwt
 }


### PR DESCRIPTION
- [x] Update library to meet the new requirements for JWS JSON serialization
- [x] Add a new function to calculate KB-JWT and then serialize in JWS JSON for an `SdJwt.Presentation`
- [x] Add a new presentation verification function that expects the SD-JWT+KB in JWS JSON format.
- [x] Add similar methods to the SD-JWT-VC verifier
- [x] Add unit tests for all cases

Closes #217 
Closes #219 