### PR TITLE
fix: solve double tilda problem

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtSerialization.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtSerialization.kt
@@ -77,7 +77,7 @@ internal object StandardSerialization {
         disclosures: Iterable<String>,
     ): String {
         val serializedDisclosures = disclosures.concat { it }
-        return "$serializedJwt$serializedDisclosures~"
+        return "$serializedJwt$serializedDisclosures"
     }
 
     /**
@@ -113,7 +113,7 @@ internal object StandardSerialization {
     }
 
     private fun <T> Iterable<T>.concat(get: (T) -> String): String =
-        joinToString(separator = "$TILDE", prefix = "$TILDE", transform = get)
+        joinToString(prefix = "$TILDE", separator = "") { "${get(it)}~" }
 }
 
 internal object JwsJsonSupport {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/StandardSerializationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/StandardSerializationTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.jca.JCAContext
+import com.nimbusds.jose.jwk.AsymmetricJWK
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator
+import com.nimbusds.jose.util.Base64URL
+import com.nimbusds.jwt.SignedJWT
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class StandardSerializationTest {
+
+    private val issuer by lazy {
+        val issuerKey = ECKeyGenerator(Curve.P_256).generate()
+        SdJwtIssuer.nimbus(signer = ECDSASigner(issuerKey), signAlgorithm = JWSAlgorithm.ES256)
+    }
+
+    @Test
+    fun `An SD-JWT without disclosures or KBJWT should end in a single ~`() {
+        val sdJwtSpec = sdJwt {
+            plain {
+                put("foo", "bar")
+            }
+        }
+        val sdJwt = issuer.issue(sdJwtSpec).getOrThrow()
+        val expected =
+            buildString {
+                append(sdJwt.jwt.serialize())
+                append("~")
+            }
+        val actual = sdJwt.serialize()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `An SD-JWT with disclosures and without KBJWT should end in a single ~`() {
+        val sdJwtSpec = sdJwt {
+            sd {
+                put("foo", "bar")
+            }
+        }
+        val sdJwt = issuer.issue(sdJwtSpec).getOrThrow()
+        val expected =
+            buildString {
+                append(sdJwt.jwt.serialize())
+                append("~")
+                for (d in sdJwt.disclosures) {
+                    append(d.value)
+                    append("~")
+                }
+            }
+        val actual = sdJwt.serialize()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `An SD-JWT without disclosures with KBJWT should not end in ~`() {
+        val sdJwtSpec = sdJwt {
+            plain {
+                put("foo", "bar")
+            }
+        }
+        val issuedSdJwt = issuer.issue(sdJwtSpec).getOrThrow()
+        val sdJwt = issuedSdJwt.present { true }
+        assertNotNull(sdJwt)
+
+        val keyBindingSigner = object : KeyBindingSigner {
+            val holderKey = ECKeyGenerator(Curve.P_256).generate()
+            private val signer = ECDSASigner(holderKey)
+            override val signAlgorithm: JWSAlgorithm = JWSAlgorithm.ES256
+            override val publicKey: AsymmetricJWK = holderKey.toPublicJWK()
+            override fun getJCAContext(): JCAContext = signer.jcaContext
+            override fun sign(p0: JWSHeader?, p1: ByteArray?): Base64URL = signer.sign(p0, p1)
+        }
+        val (pSdJwt, kbJwt) = sdJwt.serializedAndKeyBinding({ it.serialize() }, HashAlgorithm.SHA_256, keyBindingSigner) {}
+        val actual = sdJwt.serializeWithKeyBinding(HashAlgorithm.SHA_256, keyBindingSigner) {}
+        assertTrue { actual.startsWith(pSdJwt) }
+        assertTrue { actual.count { it == '~' } == 1 }
+        val (_, _, kbJwt1) = StandardSerialization.parse(actual)
+        assertNotNull(kbJwt1)
+        assertEquals(SignedJWT.parse(kbJwt).jwtClaimsSet, SignedJWT.parse(kbJwt1).jwtClaimsSet)
+    }
+}


### PR DESCRIPTION
### Double Tilde (~~) Appears When Serializing SD-JWT with Empty Disclosures

**Description**:
When calling the serialize function in the SdJwt class with an empty list of disclosures, the resulting serialized string ends with two tildes (~~). This appears to be an unintended consequence of how the concat function in StandardSerialization is designed.

**Steps to Reproduce**:
Create an SdJwt object with empty disclosures.
Call the serialize function.
Observe that the output ends with ~~.

**Cause of the Issue:**
The issue is caused by the concat function in the StandardSerialization object:

```
fun concat(
    serializedJwt: Jwt,
    disclosures: Iterable<String>,
): String {
    val serializedDisclosures = disclosures.concat { it }
    return "$serializedJwt$serializedDisclosures~"
}
```

When disclosures is empty, disclosures.concat { it } returns ~ due to the prefix in the concat function, leading to the double tilde (~~).