### PR TITLE
Upgrade to Kotlin 2.0.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.dokka.DokkaConfiguration
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
 import java.net.URL
 
@@ -48,8 +49,10 @@ java {
 
 kotlin {
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
+        languageVersion = JavaLanguageVersion.of(libs.versions.java.get())
+
         compilerOptions {
+            apiVersion = KotlinVersion.KOTLIN_2_0
             optIn = listOf("kotlin.io.encoding.ExperimentalEncodingApi")
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 dokka = "1.9.20"
 kotlin = "1.9.22"
-foojay = "0.8.0"
 spotless = "6.25.0"
 java = "17"
 kotlinxSerialization = "1.6.2"
@@ -28,7 +27,6 @@ ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 
 [plugins]
-foojay-resolver-convention = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojay" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 dokka = "1.9.20"
-kotlin = "1.9.22"
+kotlin = "2.0.20"
 spotless = "6.25.0"
 java = "17"
 kotlinxSerialization = "1.6.2"

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/JwtBase64.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/JwtBase64.kt
@@ -21,11 +21,14 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 @OptIn(ExperimentalEncodingApi::class)
 object JwtBase64 {
 
-    fun decode(value: String): ByteArray = Base64.UrlSafe.decode(value)
+    /**
+     * Base64 UrlSafe encoder/decoder that doesn't add/require padding.
+     */
+    private val base64 = Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT_OPTIONAL)
 
-    // Since the complement character "=" is optional,
-    // we can remove it to save some bits in the HTTP header
-    fun encode(value: ByteArray): String = removePadding(Base64.UrlSafe.encode(value))
+    fun decode(value: String): ByteArray = base64.decode(value)
+
+    fun encode(value: ByteArray): String = base64.encode(value)
 
     fun removePadding(value: String): String = value.replace("=", "")
 }


### PR DESCRIPTION
Addresses breaking changes to the default behavior of `Base64`.

Previously `Base64` by default added padding during encode and didn't require padding during decode.
Now `Base64` by default adds padding during encode and requires padding during decode.

`JwtBase64` has been updated to use a `Base64` instance that doesn't add padding during encode and doesn't require padding during decode, thus reverting to the previous default behavior.
