### PR TITLE
Prefer java.util.Base64 over kotlin.io.encoding.Base64

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DisclosureDigest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DisclosureDigest.kt
@@ -26,7 +26,7 @@ value class DisclosureDigest private constructor(val value: String) {
 
         /**
          * Wraps the given [string][s] into [DisclosureDigest]
-         * It expects that the given input is base64-url encoded.
+         * It expects that the given input is base64-url encoded without padding.
          * If not, an exception is thrown
          *
          * @param s the value to wrap

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/JwtBase64.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/JwtBase64.kt
@@ -15,17 +15,23 @@
  */
 package eu.europa.ec.eudi.sdjwt
 
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
+import java.util.*
+import java.util.Base64.Decoder
+import java.util.Base64.Encoder
 
-@OptIn(ExperimentalEncodingApi::class)
 object JwtBase64 {
 
-    fun decode(value: String): ByteArray = Base64.UrlSafe.decode(value)
+    /**
+     * Base64 encoder that doesn't add padding.
+     */
+    private val encoder: Encoder = Base64.getUrlEncoder().withoutPadding()
 
-    // Since the complement character "=" is optional,
-    // we can remove it to save some bits in the HTTP header
-    fun encode(value: ByteArray): String = removePadding(Base64.UrlSafe.encode(value))
+    /**
+     * Base64 decoder that doesn't require padding.
+     */
+    private val decoder: Decoder = Base64.getUrlDecoder()
 
+    fun decode(value: String): ByteArray = decoder.decode(value)
+    fun encode(value: ByteArray): String = encoder.encodeToString(value)
     fun removePadding(value: String): String = value.replace("=", "")
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/JwtBase64.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/JwtBase64.kt
@@ -21,17 +21,24 @@ import java.util.Base64.Encoder
 
 object JwtBase64 {
 
-    /**
-     * Base64 encoder that doesn't add padding.
-     */
     private val encoder: Encoder = Base64.getUrlEncoder().withoutPadding()
-
-    /**
-     * Base64 decoder that doesn't require padding.
-     */
     private val decoder: Decoder = Base64.getUrlDecoder()
 
-    fun decode(value: String): ByteArray = decoder.decode(value)
+    /**
+     * Decodes the given [value].
+     * @param value Expected to be base64 URL-encoded without padding
+     * @return the decoded content
+     * @throws IllegalArgumentException in case padding used
+     */
+    fun decode(value: String): ByteArray {
+        require(value.lastOrNull() != '=') { "No padding" }
+        return decoder.decode(value)
+    }
+
+    /**
+     * URL-Encodes the given [value] without padding
+     * @param value what to encode
+     * @return the base64 URL-encoded without padding
+     */
     fun encode(value: ByteArray): String = encoder.encodeToString(value)
-    fun removePadding(value: String): String = value.replace("=", "")
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtDigest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtDigest.kt
@@ -36,13 +36,12 @@ value class SdJwtDigest private constructor(val value: String) {
          * Wraps the given [value] to a [SdJwtDigest].
          * The [value] is expected to be base64-url encoded.
          *
-         * @param value the base64-url encoded digest value to wrap
+         * @param value the base64-url encoded without padding digest value to wrap
          * @return the wrapped value
          */
         fun wrap(value: String): Result<SdJwtDigest> = runCatching {
-            val clean = JwtBase64.removePadding(value)
-            JwtBase64.decode(clean)
-            SdJwtDigest(clean)
+            JwtBase64.decode(value)
+            SdJwtDigest(value)
         }
 
         /**

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
@@ -192,7 +192,6 @@ sealed interface KeyBindingVerifier {
                             ?.takeIf { element -> element is JsonPrimitive && element.isString }
                             ?.jsonPrimitive
                             ?.contentOrNull
-                            ?.let { JwtBase64.removePadding(it) }
                         expectedDigest.value == sdHash
                     }
                     ?: throw InvalidKeyBindingJwt.asException()


### PR DESCRIPTION
Replaces usages of Kotlin's Base64 with Java's Base64.

Closes #225