### PR TITLE
Fix verification of SD-JWT VCs signed using EdDSA/OctetKeyPair

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcJwtProcessor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcJwtProcessor.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt.vc
+
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSVerifier
+import com.nimbusds.jose.crypto.ECDSAVerifier
+import com.nimbusds.jose.crypto.Ed25519Verifier
+import com.nimbusds.jose.crypto.MACVerifier
+import com.nimbusds.jose.crypto.RSASSAVerifier
+import com.nimbusds.jose.crypto.factories.DefaultJWSVerifierFactory
+import com.nimbusds.jose.jwk.*
+import com.nimbusds.jose.jwk.source.JWKSource
+import com.nimbusds.jose.proc.BadJOSEException
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier
+import com.nimbusds.jose.proc.JWSVerificationKeySelector
+import com.nimbusds.jose.proc.SecurityContext
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.jwt.proc.BadJWTException
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier
+import com.nimbusds.jwt.proc.DefaultJWTProcessor
+import com.nimbusds.jwt.proc.JWTProcessor
+import java.security.Key
+import java.text.ParseException
+
+const val SD_JWT_VC_TYPE = "vc+sd-jwt"
+
+/**
+ * [JWTProcessor] that supports [RSAKey], [ECKey], [OctetKeyPair], and [OctetSequenceKey] signature verification.
+ *
+ * It overrides the default behavior of [DefaultJWTProcessor] and instead of using [JWSVerificationKeySelector] to
+ * select the verification [Key], and [DefaultJWSVerifierFactory] to instantiate a [JWSVerifier], it instantiates
+ * the appropriate [JWSVerifier] directly, based on the type of the selected verification [JWK] that has been
+ * selected using a [JWKSelector] instead.
+ *
+ * This allows for full support of [OctetKeyPair] which otherwise cannot be supported due the lack of
+ * [OctetKeyPair.toKeyPair], [OctetKeyPair.toPublicKey], and [OctetKeyPair.toPrivateKey] implementations required
+ * by [JWSVerificationKeySelector].
+ *
+ * **Note:** The optional dependency 'com.google.crypto.tink:tink' is required when support for [OctetKeyPair] is required.
+ */
+internal class SdJwtVcJwtProcessor<C : SecurityContext>(
+    private val jwkSource: JWKSource<C>,
+) : DefaultJWTProcessor<C>() {
+    init {
+        jwsTypeVerifier = DefaultJOSEObjectTypeVerifier(JOSEObjectType(SD_JWT_VC_TYPE))
+        jwtClaimsSetVerifier = DefaultJWTClaimsVerifier(
+            JWTClaimsSet.Builder().build(),
+            setOf("iss"),
+        )
+    }
+
+    override fun process(signedJWT: SignedJWT, context: C?): JWTClaimsSet {
+        ensureInitialized()
+
+        jwsTypeVerifier.verify(signedJWT.header.type, context)
+
+        val claimsSet = signedJWT.jwtClaimSet()
+        val jwkSelector = JWKSelector(JWKMatcher.forJWSHeader(signedJWT.header))
+
+        val jwks = jwkSource.get(jwkSelector, context)
+        if (jwks.isNullOrEmpty()) {
+            throw BadJOSEException("Signed JWT rejected: Another algorithm expected, or no matching key(s) found")
+        }
+
+        for (jwk in jwks) {
+            val verifier = jwsVerifierFor(signedJWT.header.algorithm, jwk)
+            if (signedJWT.verify(verifier)) {
+                jwtClaimsSetVerifier.verify(claimsSet, context)
+                return claimsSet
+            }
+        }
+
+        // No more keys to try out
+        throw BadJOSEException("Signed JWT rejected: Invalid signature or no matching verifier(s) found")
+    }
+
+    private fun ensureInitialized() {
+        if (jwsTypeVerifier == null) {
+            throw BadJOSEException("Signed JWT rejected: No JWS header typ (type) verifier is configured")
+        }
+
+        if (jwtClaimsSetVerifier == null) {
+            throw BadJOSEException("Signed JWT rejected: No JWTClaimSet verifier is configured")
+        }
+    }
+}
+
+private fun SignedJWT.jwtClaimSet(): JWTClaimsSet =
+    try {
+        getJWTClaimsSet()
+    } catch (e: ParseException) {
+        // Payload not a JSON object
+        throw BadJWTException(e.message, e)
+    }
+
+private fun jwsVerifierFor(algorithm: JWSAlgorithm, jwk: JWK): JWSVerifier =
+    when (algorithm) {
+        in JWSAlgorithm.Family.HMAC_SHA -> MACVerifier(jwk.expectIs<OctetSequenceKey>())
+        in JWSAlgorithm.Family.RSA -> RSASSAVerifier(jwk.expectIs<RSAKey>())
+        in JWSAlgorithm.Family.EC -> ECDSAVerifier(jwk.expectIs<ECKey>())
+        in JWSAlgorithm.Family.ED -> Ed25519Verifier(jwk.expectIs<OctetKeyPair>())
+        else -> throw BadJOSEException("Unsupported JWS algorithm $algorithm")
+    }
+
+private inline fun <reified T> JWK.expectIs(): T =
+    if (this is T) {
+        this
+    } else {
+        throw BadJOSEException("Expected a JWK of type ${T::class.java.simpleName}")
+    }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -15,25 +15,12 @@
  */
 package eu.europa.ec.eudi.sdjwt.vc
 
-import com.nimbusds.jose.JOSEObjectType
-import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.JWSVerifier
-import com.nimbusds.jose.crypto.ECDSAVerifier
-import com.nimbusds.jose.crypto.Ed25519Verifier
-import com.nimbusds.jose.crypto.MACVerifier
-import com.nimbusds.jose.crypto.RSASSAVerifier
 import com.nimbusds.jose.jwk.*
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet
 import com.nimbusds.jose.jwk.source.JWKSource
-import com.nimbusds.jose.proc.BadJOSEException
-import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier
 import com.nimbusds.jose.proc.SecurityContext
 import com.nimbusds.jose.util.X509CertUtils
-import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
-import com.nimbusds.jwt.proc.BadJWTException
-import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier
-import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import eu.europa.ec.eudi.sdjwt.*
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcIssuerPublicKeySource.*
 import io.ktor.http.*
@@ -41,7 +28,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.JsonObject
 import java.security.cert.X509Certificate
-import java.text.ParseException
 
 fun interface X509CertificateTrust {
     suspend fun isTrusted(chain: List<X509Certificate>): Boolean
@@ -278,79 +264,3 @@ internal fun keySource(jwt: SignedJWT): SdJwtVcIssuerPublicKeySource? {
         else -> null
     }
 }
-
-const val SD_JWT_VC_TYPE = "vc+sd-jwt"
-
-/**
- * Custom [DefaultJWTProcessor] implementation with support for [OctetKeyPair].
- */
-private class SdJwtVcJwtProcessor<C : SecurityContext>(
-    private val jwkSource: JWKSource<C>,
-) : DefaultJWTProcessor<C>() {
-    init {
-        jwsTypeVerifier = DefaultJOSEObjectTypeVerifier(JOSEObjectType(SD_JWT_VC_TYPE))
-        jwtClaimsSetVerifier = DefaultJWTClaimsVerifier(
-            JWTClaimsSet.Builder().build(),
-            setOf("iss"),
-        )
-    }
-
-    override fun process(signedJWT: SignedJWT, context: C?): JWTClaimsSet {
-        ensureInitialized()
-
-        jwsTypeVerifier.verify(signedJWT.header.type, context)
-
-        val claimsSet = signedJWT.jwtClaimSet()
-        val jwkSelector = JWKSelector(JWKMatcher.forJWSHeader(signedJWT.header))
-
-        val jwks = jwkSource.get(jwkSelector, context)
-        if (jwks.isNullOrEmpty()) {
-            throw BadJOSEException("Signed JWT rejected: Another algorithm expected, or no matching key(s) found")
-        }
-
-        for (jwk in jwks) {
-            val verifier = jwsVerifierFor(signedJWT.header.algorithm, jwk)
-            if (signedJWT.verify(verifier)) {
-                jwtClaimsSetVerifier.verify(claimsSet, context)
-                return claimsSet
-            }
-        }
-
-        // No more keys to try out
-        throw BadJOSEException("Signed JWT rejected: Invalid signature or no matching verifier(s) found")
-    }
-
-    private fun ensureInitialized() {
-        if (jwsTypeVerifier == null) {
-            throw BadJOSEException("Signed JWT rejected: No JWS header typ (type) verifier is configured")
-        }
-
-        if (jwtClaimsSetVerifier == null) {
-            throw BadJOSEException("Signed JWT rejected: No JWTClaimSet verifier is configured")
-        }
-    }
-}
-
-private fun SignedJWT.jwtClaimSet(): JWTClaimsSet =
-    try {
-        getJWTClaimsSet()
-    } catch (e: ParseException) {
-        // Payload not a JSON object
-        throw BadJWTException(e.message, e)
-    }
-
-private fun jwsVerifierFor(algorithm: JWSAlgorithm, jwk: JWK): JWSVerifier =
-    when (algorithm) {
-        in JWSAlgorithm.Family.HMAC_SHA -> MACVerifier(jwk.expectIs<OctetSequenceKey>())
-        in JWSAlgorithm.Family.RSA -> RSASSAVerifier(jwk.expectIs<RSAKey>())
-        in JWSAlgorithm.Family.EC -> ECDSAVerifier(jwk.expectIs<ECKey>())
-        in JWSAlgorithm.Family.ED -> Ed25519Verifier(jwk.expectIs<OctetKeyPair>())
-        else -> throw BadJOSEException("Unsupported JWS algorithm $algorithm")
-    }
-
-private inline fun <reified T> JWK.expectIs(): T =
-    if (this is T) {
-        this
-    } else {
-        throw BadJOSEException("Expected a JWK of type ${T::class.java.simpleName}")
-    }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -16,16 +16,25 @@
 package eu.europa.ec.eudi.sdjwt.vc
 
 import com.nimbusds.jose.JOSEObjectType
-import com.nimbusds.jose.jwk.JWK
-import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSVerifier
+import com.nimbusds.jose.crypto.ECDSAVerifier
+import com.nimbusds.jose.crypto.Ed25519Verifier
+import com.nimbusds.jose.crypto.MACVerifier
+import com.nimbusds.jose.crypto.RSASSAVerifier
+import com.nimbusds.jose.jwk.*
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet
-import com.nimbusds.jose.proc.*
+import com.nimbusds.jose.jwk.source.JWKSource
+import com.nimbusds.jose.proc.BadJOSEException
+import com.nimbusds.jose.proc.BadJWSException
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier
+import com.nimbusds.jose.proc.SecurityContext
 import com.nimbusds.jose.util.X509CertUtils
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.jwt.proc.BadJWTException
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier
 import com.nimbusds.jwt.proc.DefaultJWTProcessor
-import com.nimbusds.jwt.proc.JWTProcessor
 import eu.europa.ec.eudi.sdjwt.*
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcIssuerPublicKeySource.*
 import io.ktor.http.*
@@ -33,6 +42,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.JsonObject
 import java.security.cert.X509Certificate
+import java.text.ParseException
 
 fun interface X509CertificateTrust {
     suspend fun isTrusted(chain: List<X509Certificate>): Boolean
@@ -183,40 +193,38 @@ fun sdJwtVcSignatureVerifier(
 ): JwtSignatureVerifier = JwtSignatureVerifier { unverifiedJwt ->
     try {
         val signedJwt = SignedJWT.parse(unverifiedJwt)
-        val keySelector = issuerJwsKeySelector(httpClientFactory, trust, lookup, signedJwt)
-        checkNotNull(keySelector) { "Failed to resolve issuer public key" }
-        val jwtProcessor = sdJwtVcProcessor(keySelector)
+        val jwkSource = issuerJwkSource(httpClientFactory, trust, lookup, signedJwt)
+        checkNotNull(jwkSource) { "Failed to resolve issuer public key" }
+        val jwtProcessor = SdJwtVcJwtProcessor(jwkSource)
         jwtProcessor.process(signedJwt, null).asClaims()
     } catch (e: Throwable) {
         null
     }
 }
 
-private suspend fun issuerJwsKeySelector(
+private suspend fun issuerJwkSource(
     httpClientFactory: KtorHttpClientFactory,
     trust: X509CertificateTrust,
     lookup: LookupPublicKeysFromDIDDocument?,
     signedJwt: SignedJWT,
-): JWSKeySelector<SecurityContext>? {
-    val algorithm = requireNotNull(signedJwt.header.algorithm) { "missing 'alg'" }
-    suspend fun fromMetadata(source: Metadata): JWSKeySelector<SecurityContext> =
+): JWKSource<SecurityContext>? {
+    suspend fun fromMetadata(source: Metadata): JWKSource<SecurityContext> =
         httpClientFactory.invoke().use { httpClient ->
             val fetcher = SdJwtVcIssuerMetaDataFetcher(httpClient)
             val (_, jwks) = fetcher.fetchMetaData(source.iss)
-            JWSVerificationKeySelector(algorithm, ImmutableJWKSet(jwks))
+            ImmutableJWKSet(jwks)
         }
 
-    suspend fun fromX509CertChain(source: X509CertChain): JWSKeySelector<SecurityContext>? =
+    suspend fun fromX509CertChain(source: X509CertChain): JWKSource<SecurityContext>? =
         if (trust.isTrusted(source.chain)) {
-            val publicKey = source.chain.first().publicKey
-            SingleKeyJWSKeySelector(algorithm, publicKey)
+            val jwk = JWK.parse(source.chain.first())
+            ImmutableJWKSet(JWKSet(mutableListOf(jwk)))
         } else null
 
-    suspend fun fromDid(source: DIDUrl): JWSKeySelector<SecurityContext>? =
+    suspend fun fromDid(source: DIDUrl): JWKSource<SecurityContext>? =
         lookup
             ?.lookup(source.iss, source.kid)
-            ?.takeIf { it.isNotEmpty() }
-            ?.let { publicKeys -> JWSVerificationKeySelector(algorithm, ImmutableJWKSet(JWKSet(publicKeys))) }
+            ?.let { ImmutableJWKSet(JWKSet(it)) }
 
     return when (val source = keySource(signedJwt)) {
         null -> null
@@ -272,14 +280,78 @@ internal fun keySource(jwt: SignedJWT): SdJwtVcIssuerPublicKeySource? {
     }
 }
 
-private fun sdJwtVcProcessor(keySelector: JWSKeySelector<SecurityContext>): JWTProcessor<SecurityContext> =
-    DefaultJWTProcessor<SecurityContext>().apply {
+const val SD_JWT_VC_TYPE = "vc+sd-jwt"
+
+/**
+ * Custom [DefaultJWTProcessor] implementation with support for [OctetKeyPair].
+ */
+private class SdJwtVcJwtProcessor<C : SecurityContext>(
+    private val jwkSource: JWKSource<C>,
+) : DefaultJWTProcessor<C>() {
+    init {
         jwsTypeVerifier = DefaultJOSEObjectTypeVerifier(JOSEObjectType(SD_JWT_VC_TYPE))
-        jwsKeySelector = keySelector
         jwtClaimsSetVerifier = DefaultJWTClaimsVerifier(
             JWTClaimsSet.Builder().build(),
             setOf("iss"),
         )
     }
 
-const val SD_JWT_VC_TYPE = "vc+sd-jwt"
+    override fun process(signedJWT: SignedJWT, context: C?): JWTClaimsSet {
+        ensureInitialized()
+
+        jwsTypeVerifier.verify(signedJWT.header.type, context)
+
+        val claimsSet = signedJWT.jwtClaimSet()
+        val jwkSelector = JWKSelector(JWKMatcher.forJWSHeader(signedJWT.header))
+
+        val jwks = jwkSource.get(jwkSelector, context)
+        if (jwks.isNullOrEmpty()) {
+            throw BadJOSEException("Signed JWT rejected: Another algorithm expected, or no matching key(s) found")
+        }
+
+        for (jwk in jwks) {
+            val verifier = jwsVerifierFor(signedJWT.header.algorithm, jwk)
+            if (signedJWT.verify(verifier)) {
+                jwtClaimsSetVerifier.verify(claimsSet, context)
+                return claimsSet
+            }
+        }
+
+        // No more keys to try out
+        throw BadJWSException("Signed JWT rejected: Invalid signature or no matching verifier(s) found")
+    }
+
+    private fun ensureInitialized() {
+        if (jwsTypeVerifier == null) {
+            throw BadJOSEException("Signed JWT rejected: No JWS header typ (type) verifier is configured")
+        }
+
+        if (jwtClaimsSetVerifier == null) {
+            throw BadJOSEException("Signed JWT rejected: No JWTClaimSet verifier is configured")
+        }
+    }
+}
+
+private fun SignedJWT.jwtClaimSet(): JWTClaimsSet =
+    try {
+        getJWTClaimsSet()
+    } catch (e: ParseException) {
+        // Payload not a JSON object
+        throw BadJWTException(e.message, e)
+    }
+
+private fun jwsVerifierFor(algorithm: JWSAlgorithm, jwk: JWK): JWSVerifier =
+    when (algorithm) {
+        in JWSAlgorithm.Family.HMAC_SHA -> MACVerifier(jwk.expectIs<OctetSequenceKey>())
+        in JWSAlgorithm.Family.RSA -> RSASSAVerifier(jwk.expectIs<RSAKey>())
+        in JWSAlgorithm.Family.EC -> ECDSAVerifier(jwk.expectIs<ECKey>())
+        in JWSAlgorithm.Family.ED -> Ed25519Verifier(jwk.expectIs<OctetKeyPair>())
+        else -> throw BadJOSEException("Unsupported JWS algorithm $algorithm")
+    }
+
+private inline fun <reified T> JWK.expectIs(): T =
+    if (this is T) {
+        this
+    } else {
+        throw BadJOSEException("Expected a JWK of type ${T::class.java.simpleName}")
+    }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -26,7 +26,6 @@ import com.nimbusds.jose.jwk.*
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet
 import com.nimbusds.jose.jwk.source.JWKSource
 import com.nimbusds.jose.proc.BadJOSEException
-import com.nimbusds.jose.proc.BadJWSException
 import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier
 import com.nimbusds.jose.proc.SecurityContext
 import com.nimbusds.jose.util.X509CertUtils
@@ -318,7 +317,7 @@ private class SdJwtVcJwtProcessor<C : SecurityContext>(
         }
 
         // No more keys to try out
-        throw BadJWSException("Signed JWT rejected: Invalid signature or no matching verifier(s) found")
+        throw BadJOSEException("Signed JWT rejected: Invalid signature or no matching verifier(s) found")
     }
 
     private fun ensureInitialized() {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleReadMeTest01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleReadMeTest01.kt
@@ -44,4 +44,14 @@ class ExampleReadMeTest01 {
     fun testExampleRecreateClaims01() {
         println(claims)
     }
+
+    @Test
+    fun testExampleSdJwtWithMinimumDigest01() {
+        println(sdJwtWithMinimumDigests)
+    }
+
+    @Test
+    fun testExampleSdJwtVcVerification01() {
+        sdJwtVcVerification.getOrThrow()
+    }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt.examples
+
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.crypto.Ed25519Signer
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator
+import eu.europa.ec.eudi.sdjwt.*
+import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerifier
+import kotlinx.coroutines.runBlocking
+import kotlin.io.encoding.Base64
+import kotlin.test.assertEquals
+
+val sdJwtVcVerification = runBlocking {
+    val key = OctetKeyPairGenerator(Curve.Ed25519).generate()
+    val didJwk = "did:jwk:${Base64.UrlSafe.encode(key.toPublicJWK().toJSONString().toByteArray())}"
+
+    val sdJwt = run {
+        val spec = sdJwt {
+            iss(didJwk)
+        }
+        val signer = SdJwtIssuer.nimbus(signer = Ed25519Signer(key), signAlgorithm = JWSAlgorithm.EdDSA) {
+            type(JOSEObjectType("vc+sd-jwt"))
+        }
+        signer.issue(spec).getOrThrow()
+    }
+
+    val verifier = SdJwtVcVerifier { did, _ ->
+        assertEquals(didJwk, did)
+        listOf(key.toPublicJWK())
+    }
+    verifier.verifyIssuance(sdJwt.serialize())
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtWithMinimumDigest01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtWithMinimumDigest01.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt.examples
+
+import eu.europa.ec.eudi.sdjwt.*
+
+val sdJwtWithMinimumDigests = sdJwt(minimumDigests = 5) {
+    // This 5 guarantees that at least 5 digests will be found
+    // to the digest array, regardless of the content of the SD-JWT
+    structured("address", minimumDigests = 10) {
+        // This affects the nested array of the digests that will
+        // have at list 10 digests.
+    }
+
+    recursive("address1", minimumDigests = 8) {
+        // This will affect the digests array that will be found
+        // in the disclosure of this recursively disclosable item
+        // the whole object will be embedded in its parent
+        // as a single digest
+    }
+
+    sdArray("evidence", minimumDigests = 2) {
+        // Array will have at least 2 digests
+        // regardless of its elements
+    }
+
+    recursiveArray("evidence1", minimumDigests = 2) {
+        // Array will have at least 2 digests
+        // regardless of its elements
+        // the whole array will be embedded in its parent
+        // as a single digest
+    }
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -19,11 +19,13 @@ import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.crypto.Ed25519Signer
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
+import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.sdjwt.*
@@ -41,6 +43,7 @@ import kotlinx.serialization.json.put
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.time.Instant
+import kotlin.io.encoding.Base64
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -186,4 +189,28 @@ class SdJwtVcVerifierTest {
         }
         assertEquals(VerificationError.InvalidJwt, exception.reason)
     }
+
+    @Test
+    fun `SdJwtVcVerifier should verify an SD-JWT-VC that has been signed using an OctetKeyPair using Ed25519 curve and EdDSA algorithm`() =
+        runTest {
+            val key = OctetKeyPairGenerator(Curve.Ed25519).generate()
+            val didJwk = "did:jwk:${Base64.UrlSafe.encode(key.toPublicJWK().toJSONString().toByteArray())}"
+
+            val sdJwt = run {
+                val spec = sdJwt {
+                    iss(didJwk)
+                }
+                val signer = SdJwtIssuer.nimbus(signer = Ed25519Signer(key), signAlgorithm = JWSAlgorithm.EdDSA) {
+                    type(JOSEObjectType(SD_JWT_VC_TYPE))
+                }
+                signer.issue(spec)
+            }.getOrThrow()
+
+            val verifier = SdJwtVcVerifier { did, _ ->
+                assertEquals(didJwk, did)
+                listOf(key.toPublicJWK())
+            }
+
+            verifier.verifyIssuance(sdJwt.serialize()).getOrThrow()
+        }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -203,8 +203,8 @@ class SdJwtVcVerifierTest {
                 val signer = SdJwtIssuer.nimbus(signer = Ed25519Signer(key), signAlgorithm = JWSAlgorithm.EdDSA) {
                     type(JOSEObjectType(SD_JWT_VC_TYPE))
                 }
-                signer.issue(spec)
-            }.getOrThrow()
+                signer.issue(spec).getOrThrow()
+            }
 
             val verifier = SdJwtVcVerifier { did, _ ->
                 assertEquals(didJwk, did)


### PR DESCRIPTION
The main problem comes from Nimbus `DefaultJWTProcessor` which when processing a signed JWT :
- Requires all JWKs representing an issuer's pub keys to be representing a `java.security.Key`, yet
- `OctetKeyPair` doesn't implement the above conversion.

Solution provided by this PR, is to replace in the context of `sd-jwt-vc` verification the `DefaultJWTProcessor` with a custom processor, that 
- accepts a list of issuer pub keys (extracted by the sd-jwt-vc discovery process)
- instantiates an appropriate verifier (in the ED case there is Nimbus `Ed25519Verifier` that accepts the JWK)
- considers dig sig as valid, on the first verifier that succeeds.
- All other checks (for `typ`, claim set content etc, are preserved)

The above solution requires that caller includes on the class path Tink library, on its own.

Closes #229