### PR TITLE
Add an example of PID SD-JWT-VC verificaiton (issuance)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,9 +37,20 @@ dependencies {
     api(libs.ktor.client.serialization)
     api(libs.ktor.serialization.kotlinx.json)
     testImplementation(kotlin("test"))
-    testImplementation(libs.tink)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.ktor.client.mock)
+    testImplementation(libs.tink) {
+        because("To allow tests against ECDSA curves")
+    }
+    testImplementation(libs.ktor.client.java) {
+        because("Register an Engine for tests")
+    }
+    testImplementation(libs.ktor.client.logging) {
+        because("Allow logging of HTTP requests/responses")
+    }
+    testImplementation(libs.logback.classic) {
+        because("Allow logging of HTTP requests/responses. Ktor client delegates logging")
+    }
 }
 
 java {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ kotlinx-knit = "0.5.0"
 tink = "1.15.0"
 kotlinxCoroutines = "1.8.1"
 ktor = "2.3.12"
+logback = "1.5.12"
 
 [libraries]
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
@@ -26,6 +27,9 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor-client-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+ktor-client-logging = {module ="io.ktor:ktor-client-logging", version.ref="ktor"}
+ktor-client-java = {module ="io.ktor:ktor-client-java", version.ref="ktor"}
+logback-classic = {module="ch.qos.logback:logback-classic", version.ref="logback"}
 
 [plugins]
 foojay-resolver-convention = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojay" }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuerMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuerMetaData.kt
@@ -65,7 +65,7 @@ private fun issuerMetadataUrl(issuer: Url): Url =
 
 @Serializable
 private data class SdJwtVcIssuerMetadataTO(
-    val issuer: String,
+    @SerialName("issuer") val issuer: String,
     @SerialName("jwks_uri") val jwksUri: String? = null,
     @SerialName("jwks") val jwks: JsonObject? = null,
 )

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt
+
+import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerifier
+import io.ktor.client.*
+import io.ktor.client.engine.java.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.cookies.*
+import io.ktor.client.plugins.logging.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Ignore
+import kotlin.test.Test
+
+class PidDevVerificationTest {
+
+    @Test @Ignore
+    fun test() = runTest {
+        val sampleIssuedPid = """
+            eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJfc2QiOlsiQ3lKR3d0WDc2VmpJMVI4S0Z5a0JNcWw4aHNkYXRkckFWY2dXdE1FRXlrYyIsIkZDOThzQ2UxbkkxcllJV0pJSlBxVjB3V0xXVWhLbEo2SDE5aVhjajhwQVkiLCJKTmdOSlg0S3lwcnAyUTJzMHV6QlVhbXEtNnQxa2VHRVZfak5SSWFnZjMwIiwiVzRNemRnVmVRaTZTUHlRX2FyelV6WGEyZ2ZydU5ETXNhc0JXYjlHNW5jdyIsImZZeWszWUJqVDlYRVIxVHhtaE9WNW0yZzJJTm5LdTNTQ0hFU2xGZVI0MVkiLCJuR2o1MFVFczR0UnVOSUZlMnVPMDVHWTZQS0U5SXdXQU8yZ0FpbUFSQlZvIiwibmljMmhmM1JrRm1sV012WVpWOWJNOVZJbEwtZWJKV2h6eDQzQk9SM2RjYyIsInd2VDl4b05VczNHckZIRTZCTVJZV3h1ZjFISlpUM19KQ21qZ01adHdXVEkiXSwidmN0IjoiZXUuZXVyb3BhLmVjLmV1ZGkucGlkLjEiLCJfc2RfYWxnIjoic2hhMy0yNTYiLCJpc3MiOiJodHRwczovL2Rldi5pc3N1ZXItYmFja2VuZC5ldWRpdy5kZXYiLCJjbmYiOnsiandrIjp7Imt0eSI6IlJTQSIsImUiOiJBUUFCIiwidXNlIjoic2lnIiwia2lkIjoiZjhiOTQ0ZjYtZWY4OC00MWE5LWJkM2UtNjliNTQ3ZTI4ZTc2IiwiaWF0IjoxNzMyMTAxMjg1LCJuIjoidVV5V25TVkdPRGJNMGVOQUh3MXJmRDJXYW9wUHpES2UtTHJjbnBvYnlwWVRyQTliUmNsQVhsVUtYZW5Jck01VnZZWlFuWGpRUU9DYmo0dl9ZM2UzZzJkaGQzSkREamE4d3F2VnVwVHlXMndsUU9nTDdyQ3IyVUYwUzVWejEtVFBlXzBSd2s4dmpKM2ZvZHJCWUxva0J5UXl0T0hvRVFWVDYwZGNNRUM5bEJsXy1OU0s5UENjeExzakVUSWcyaWN6OTI1cWhkTFR1cG1uYmpqM2RuOS0tNUplcEs3cE9FcWktX2pBbTU3VkNLRDU4clMxTW1JZl85NFhGVnhNbm9hS3FTNmdKbk8tZ05yRXpGYzlWZXIyMlJnTEZvY2x2NC0waVRNMFhYbkJBQzJWTDhQZk5uaGZjYTNxcnBjd2x2MGRkYWtZOHlBeUlsbG9ldDJsNllaOG9RIn19LCJleHAiOjE3MzQ2OTMyODYsImlhdCI6MTczMjEwMTI4NiwiYWdlX2VxdWFsX29yX292ZXIiOnsiX3NkIjpbIkl1cS1YUzFCeUlyaUtSSkdwc2ZCd2FPQ2w2NVctWGd4X1p2cVFCbGNkWWMiXX19.8dWnQm64W11vsdY0IqJh6TUuneyOMcvxqvRMu1ZY5hPOiPyL0D7aGoPSZl7lbgpBWOFtvzmruNoKePgpT5IGMw~WyJTSWhZMnl3ay14SFJzV05xNWRHckV3IiwiaXNzdWFuY2VfZGF0ZSIsIjIwMjQtMTEtMjAiXQ~WyJ5NHRjQm9tX214QVI0N2czN25iOFdRIiwiZ2l2ZW5fbmFtZSIsIlR5bGVyIl0~WyJFcF9aVXBVVXhoSDI2Yk1YUE5CaGpRIiwiZmFtaWx5X25hbWUiLCJOZWFsIl0~WyJWeGJNdDc3UU9BSDItck03YlpNbHVRIiwiYmlydGhkYXRlIiwiMTk1NS0wNC0xMiJd~WyJUSWFFRXhfTXh5OUdvbjJhSHlLSHB3IiwiMTgiLHRydWVd~WyJ2RVB2NjhZNGJDOUpSZnoyOGNpS2h3IiwiZ2VuZGVyIiwxXQ~WyJQcEVwNzgtOXRpRFVqUnRlVmQ4S0pRIiwiYWdlX2luX3llYXJzIiw3MF0~WyJ0UFlQWk9PM1ZLcEJHY3ZxY3ZFN1B3IiwiYmlydGhkYXRlX3llYXIiLCIxOTU1Il0~WyJxd0tqcjllY3ZwX2laOWktRWpHZE1RIiwiY291bnRyeSIsIkFUIl0~WyJWUXdjUXZLcWo3dGh6OFB3aXJIQ3JBIiwicmVnaW9uIiwiTG93ZXIgQXVzdHJpYSJd~WyJrTEN4OG1FR3RLZDM2UXBOaFg2Q3BnIiwibG9jYWxpdHkiLCJHZW1laW5kZSBCaWJlcmJhY2giXQ~WyIzZy13cmxaU0drZ1dYbm9qaFBDTk1BIiwicG9zdGFsX2NvZGUiLCIzMzMxIl0~WyI2TkFUZGVFTjdiZDZSR0MtU3ZnM0RBIiwic3RyZWV0X2FkZHJlc3MiLCIxMDEgVHJhdW5lciJd~WyI3VmRDYlA5b2lFR19YNjRUWlU4dnFBIiwiYWRkcmVzcyIseyJfc2QiOlsiYVUwd2lWY2JSNzA2ekZSZ1VkR1A5bWhqYnpnV1diR2xYYWJqbnROTDZXbyIsImV1WTN6OHFYT1hDMmYycTZTX21mV0ZWUU5ZcWxPd01XeWVjaVlaaGp1TkEiLCJrUnVKd2pPNlR5YlhoVnRYLXRZcFc0YWlpRVZKdzFVdG9rek4tYTNkNEdNIiwic2lIM1BRUkVsU2laTk9xcm9LNG0yN3Foc2dyRy1sb0p0NFdnZmtmZ1RZQSIsInk4RTRMZ1dyTVlIMFV2V2JzNmhDVEc0NzBGaml6Rm0wbGlVdTk2dDQtR2MiXX1d~
+        """.trimIndent()
+
+        val verifier = SdJwtVcVerifier(
+            httpClientFactory = { createHttpClient(enableLogging = true) },
+            trust = { x5c -> true },
+        )
+
+        val issuedSdJwt = run {
+            val tmp = verifier.verifyIssuance(sampleIssuedPid).getOrThrow()
+            SdJwt.Issuance(tmp.jwt.second, tmp.disclosures)
+        }
+
+        // Output the debug info
+        printHeader("Debug info")
+        issuedSdJwt.prettyPrint { it }
+
+        // Recreate claims & calculate the disclosures map
+        val (originalJson, disclosureMap) =
+            run {
+                val (originalClaims, disclosureMap) = issuedSdJwt.recreateClaimsAndDisclosuresPerClaim { it }
+                JsonObject(originalClaims) to disclosureMap
+            }
+
+        printHeader("Recreated claims")
+        println(json.encodeToString(originalJson))
+
+        printHeader("Disclosure map")
+        disclosureMap.prettyPrint()
+    }
+
+    private fun printHeader(s: String) {
+        repeat(5) { println() }
+
+        println("========== $s ==========")
+    }
+}
+
+internal fun createHttpClient(enableLogging: Boolean = true): HttpClient = HttpClient(Java) {
+    install(ContentNegotiation) {
+        json(json)
+    }
+    install(HttpCookies)
+    if (enableLogging) {
+        install(Logging) {
+            logger = Logger.DEFAULT
+            level = LogLevel.ALL
+        }
+    }
+}


### PR DESCRIPTION
The PR adds some dependencies to the test scope so that SD-JWT-VC Metadata can be obtained from live servers.