### PR TITLE
Allow a client to configure/enable its preferred method of SD-JWT-VC signing key resolution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerifier
 import kotlinx.coroutines.runBlocking
 import kotlin.io.encoding.Base64
 import kotlin.test.assertEquals
+import kotlin.test.fail
 -->
 
 ```kotlin
@@ -420,10 +421,13 @@ val sdJwtVcVerification = runBlocking {
         signer.issue(spec).getOrThrow()
     }
 
-    val verifier = SdJwtVcVerifier { did, _ ->
-        assertEquals(didJwk, did)
-        listOf(key.toPublicJWK())
-    }
+    val verifier = SdJwtVcVerifier.builder()
+        .enableX509CertificateTrust { _ -> fail("X509Certificate trust should not have been used") }
+        .enableDidResolution { did, _ ->
+            assertEquals(didJwk, did)
+            listOf(key.toPublicJWK())
+        }
+        .build()
     verifier.verifyIssuance(sdJwt.serialize())
 }
 ```

--- a/README.md
+++ b/README.md
@@ -421,13 +421,13 @@ val sdJwtVcVerification = runBlocking {
         signer.issue(spec).getOrThrow()
     }
 
-    val verifier = SdJwtVcVerifier.builder()
-        .enableX509CertificateTrust { _ -> fail("X509Certificate trust should not have been used") }
-        .enableDidResolution { did, _ ->
-            assertEquals(didJwk, did)
-            listOf(key.toPublicJWK())
-        }
-        .build()
+    val verifier = SdJwtVcVerifier(
+        x509CertificateTrust = { _ -> fail("X509Certificate trust should not have been used") },
+    ) { did, _ ->
+        assertEquals(didJwk, did)
+        listOf(key.toPublicJWK())
+    }
+
     verifier.verifyIssuance(sdJwt.serialize())
 }
 ```

--- a/README.md
+++ b/README.md
@@ -403,7 +403,6 @@ import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerifier
 import kotlinx.coroutines.runBlocking
 import kotlin.io.encoding.Base64
 import kotlin.test.assertEquals
-import kotlin.test.fail
 -->
 
 ```kotlin
@@ -421,9 +420,7 @@ val sdJwtVcVerification = runBlocking {
         signer.issue(spec).getOrThrow()
     }
 
-    val verifier = SdJwtVcVerifier(
-        x509CertificateTrust = { _ -> fail("X509Certificate trust should not have been used") },
-    ) { did, _ ->
+    val verifier = SdJwtVcVerifier.usingDID { did, _ ->
         assertEquals(didJwk, did)
         listOf(key.toPublicJWK())
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,9 @@ dependencies {
     testImplementation(libs.logback.classic) {
         because("Allow logging of HTTP requests/responses. Ktor client delegates logging")
     }
+    testImplementation(libs.bouncy.castle) {
+        because("To generate self-signed X509 Certificates")
+    }
 }
 
 java {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ tink = "1.15.0"
 kotlinxCoroutines = "1.8.1"
 ktor = "2.3.12"
 logback = "1.5.12"
+bouncyCastle = "1.78.1"
 
 [libraries]
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
@@ -30,6 +31,7 @@ ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-client-logging = {module ="io.ktor:ktor-client-logging", version.ref="ktor"}
 ktor-client-java = {module ="io.ktor:ktor-client-java", version.ref="ktor"}
 logback-classic = {module="ch.qos.logback:logback-classic", version.ref="logback"}
+bouncy-castle = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncyCastle" }
 
 [plugins]
 foojay-resolver-convention = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojay" }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -172,11 +172,11 @@ class SdJwtVcVerifier(
         fun usingDID(didLookup: LookupPublicKeysFromDIDDocument): SdJwtVcVerifier = SdJwtVcVerifier(lookup = didLookup)
 
         /**
-         * Creates a new [SdJwtVcVerifier] with SD-JWT-VC Issuer Metadata resolution enabled, X509 Certificate trust enabled.
+         * Creates a new [SdJwtVcVerifier] with X509 Certificate trust, and SD-JWT-VC Issuer Metadata resolution enabled.
          */
-        fun usingIssuerMetadataOrX5c(
-            httpClientFactory: KtorHttpClientFactory,
+        fun usingX5cOrIssuerMetadata(
             x509CertificateTrust: X509CertificateTrust,
+            httpClientFactory: KtorHttpClientFactory,
         ): SdJwtVcVerifier = SdJwtVcVerifier(httpClientFactory = httpClientFactory, trust = x509CertificateTrust)
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -231,7 +231,7 @@ private suspend fun issuerJwkSource(
             fetcher.fetchMetaData(source.iss)
                 ?.let { (_, jwks) -> ImmutableJWKSet(jwks) }
                 ?: invalidSdJwtVc("Failed to get SD-JWT-VC metadata of ${source.iss}")
-        } ?: invalidSdJwtVc("SD-JWT-VC Issuer metadata resolution is not enabled")
+        } ?: invalidSdJwtVc("SD-JWT-VC validation requires Issuer's metadata resolution, which is not enabled")
 
     suspend fun fromX509CertChain(source: X509CertChain): JWKSource<SecurityContext> =
         trust?.let {
@@ -239,13 +239,13 @@ private suspend fun issuerJwkSource(
                 val jwk = JWK.parse(source.chain.first())
                 ImmutableJWKSet(JWKSet(mutableListOf(jwk)))
             } else invalidSdJwtVc("Leaf certificate is not trusted")
-        } ?: invalidSdJwtVc("X509 Certificate trust is not enabled")
+        } ?: invalidSdJwtVc("SD-JWT-VC validation requires x5c validation, which is not enabled")
 
     suspend fun fromDid(source: DIDUrl): JWKSource<SecurityContext> =
         lookup?.let {
             val jwks = it.lookup(source.iss, source.kid) ?: invalidSdJwtVc("Failed to resolve $source")
             SdJwtVcJwtProcessor.didJwkSet(signedJwt.header, JWKSet(jwks))
-        } ?: invalidSdJwtVc("DID resolution is not enabled")
+        } ?: invalidSdJwtVc("SD-JWT-VC validation requires DID resolution, which is not enabled")
 
     return when (val source = keySource(signedJwt)) {
         is Metadata -> fromMetadata(source)

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -148,60 +148,33 @@ class SdJwtVcVerifier private constructor(
     companion object {
 
         /**
-         * Gets a new [Builder].
+         * Creates a new [SdJwtVcVerifier] with SD-JWT-VC Issuer Metadata resolution enabled, and optionally DID resolution enabled.
          */
-        fun builder(): Builder = Builder()
-    }
-
-    /**
-     * Builder for [SdJwtVcVerifier].
-     *
-     * To successfully instantiate an [SdJwtVcVerifier] you must either enable SD-JWT-VC Issuer metadata resolution using
-     * [enableIssuerMetadataResolution], or X509 Certificate trust using [enableX509CertificateTrust]. You can optionally
-     * enable DID resolution using [enableDidResolution].
-     */
-    class Builder(
-        private var _httpClientFactory: KtorHttpClientFactory? = null,
-        private var _x509CertificateTrust: X509CertificateTrust? = null,
-        private var _didLookup: LookupPublicKeysFromDIDDocument? = null,
-    ) {
+        operator fun invoke(
+            httpClientFactory: KtorHttpClientFactory,
+            didLookup: LookupPublicKeysFromDIDDocument? = null,
+        ): SdJwtVcVerifier =
+            SdJwtVcVerifier(httpClientFactory = httpClientFactory, trust = null, lookup = didLookup)
 
         /**
-         * Enables SD-JWT-VC Issuer metadata resolution using [httpClientFactory].
+         * Creates a new [SdJwtVcVerifier] with X509 Certificate trust enabled, and optionally DID resolution enabled.
          */
-        fun enableIssuerMetadataResolution(httpClientFactory: KtorHttpClientFactory = DefaultHttpClientFactory): Builder =
-            apply {
-                _httpClientFactory = httpClientFactory
-            }
+        operator fun invoke(
+            x509CertificateTrust: X509CertificateTrust,
+            didLookup: LookupPublicKeysFromDIDDocument? = null,
+        ): SdJwtVcVerifier =
+            SdJwtVcVerifier(httpClientFactory = null, trust = x509CertificateTrust, lookup = didLookup)
 
         /**
-         * Enables [X509CertificateTrust] using [x509CertificateTrust].
+         * Creates a new [SdJwtVcVerifier] with SD-JWT-VC Issuer Metadata resolution enabled, X509 Certificate trust enabled,
+         * and optionally DID resolution enabled.
          */
-        fun enableX509CertificateTrust(x509CertificateTrust: X509CertificateTrust): Builder =
-            apply {
-                _x509CertificateTrust = x509CertificateTrust
-            }
-
-        /**
-         * Enables DID document resolution using [didLookup].
-         */
-        fun enableDidResolution(didLookup: LookupPublicKeysFromDIDDocument): Builder =
-            apply {
-                _didLookup = didLookup
-            }
-
-        /**
-         * Builds a new [SdJwtVcVerifier] based on the configuration provided.
-         */
-        fun build(): SdJwtVcVerifier {
-            val httpClientFactory = _httpClientFactory
-            val x509CertificateTrust = _x509CertificateTrust
-            val didLookup = _didLookup
-
-            return if (httpClientFactory != null || x509CertificateTrust != null) {
-                SdJwtVcVerifier(httpClientFactory, x509CertificateTrust, didLookup)
-            } else throw IllegalStateException("SD-JWT VC Issuer Metadata resolution or X509 Certificate trust must be enabled")
-        }
+        operator fun invoke(
+            httpClientFactory: KtorHttpClientFactory,
+            x509CertificateTrust: X509CertificateTrust,
+            didLookup: LookupPublicKeysFromDIDDocument? = null,
+        ): SdJwtVcVerifier =
+            SdJwtVcVerifier(httpClientFactory = httpClientFactory, trust = x509CertificateTrust, lookup = didLookup)
     }
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -262,7 +262,7 @@ private suspend fun issuerJwkSource(
  */
 internal sealed interface SdJwtVcIssuerPublicKeySource {
 
-    data class Metadata(val iss: Url) : SdJwtVcIssuerPublicKeySource
+    data class Metadata(val iss: Url, val kid: String?) : SdJwtVcIssuerPublicKeySource
 
     data class X509CertChain(val iss: Url, val chain: List<X509Certificate>) : SdJwtVcIssuerPublicKeySource
 
@@ -297,7 +297,7 @@ internal fun keySource(jwt: SignedJWT): SdJwtVcIssuerPublicKeySource {
             else invalidSdJwtVc("Failed to find $issUrl in URI or DNS entries of provided leaf certificate")
         }
 
-        issScheme == HTTPS_URI_SCHEME -> Metadata(issUrl)
+        issScheme == HTTPS_URI_SCHEME -> Metadata(issUrl, kid)
         issScheme == DID_URI_SCHEME && certChain.isEmpty() -> DIDUrl(iss, kid)
         else -> invalidSdJwtVc("Failed to identify a source for Issuer's pub key")
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -53,7 +53,10 @@ class KeyBindingTest {
 
     private val issuer = IssuerActor(genKey("issuer"))
     private val lookup = LookupPublicKeysFromDIDDocument { _, _ -> listOf(issuer.issuerKey.toPublicJWK()) }
-    private val verifier = SdJwtVcVerifier(lookup = lookup)
+    private val verifier = SdJwtVcVerifier.builder()
+        .enableIssuerMetadataResolution()
+        .enableDidResolution(lookup)
+        .build()
     private val holder = HolderActor(genKey("holder"), lookup)
 
     /**
@@ -238,7 +241,10 @@ class HolderActor(
     holderKey: ECKey,
     lookup: LookupPublicKeysFromDIDDocument,
 ) {
-    private val verifier = SdJwtVcVerifier(lookup = lookup)
+    private val verifier = SdJwtVcVerifier.builder()
+        .enableIssuerMetadataResolution()
+        .enableDidResolution(lookup)
+        .build()
     private val keyBindingSigner: KeyBindingSigner by lazy {
         val actualSigner = ECDSASigner(holderKey)
         object : KeyBindingSigner {
@@ -297,7 +303,10 @@ class VerifierActor(
     private val whatToDisclose: Set<String>,
     lookup: LookupPublicKeysFromDIDDocument,
 ) {
-    private val verifier = SdJwtVcVerifier(lookup = lookup)
+    private val verifier = SdJwtVcVerifier.builder()
+        .enableIssuerMetadataResolution()
+        .enableDidResolution(lookup)
+        .build()
     private var lastChallenge: JsonObject? = null
     private var presentation: SdJwt.Presentation<JwtAndClaims>? = null
     fun query(): VerifierQuery = VerifierQuery(

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -27,6 +27,7 @@ import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jose.util.Base64URL
 import com.nimbusds.jwt.SignedJWT
+import eu.europa.ec.eudi.sdjwt.vc.DefaultHttpClientFactory
 import eu.europa.ec.eudi.sdjwt.vc.LookupPublicKeysFromDIDDocument
 import eu.europa.ec.eudi.sdjwt.vc.SD_JWT_VC_TYPE
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerifier
@@ -53,10 +54,7 @@ class KeyBindingTest {
 
     private val issuer = IssuerActor(genKey("issuer"))
     private val lookup = LookupPublicKeysFromDIDDocument { _, _ -> listOf(issuer.issuerKey.toPublicJWK()) }
-    private val verifier = SdJwtVcVerifier.builder()
-        .enableIssuerMetadataResolution()
-        .enableDidResolution(lookup)
-        .build()
+    private val verifier = SdJwtVcVerifier(httpClientFactory = DefaultHttpClientFactory, didLookup = lookup)
     private val holder = HolderActor(genKey("holder"), lookup)
 
     /**
@@ -241,10 +239,7 @@ class HolderActor(
     holderKey: ECKey,
     lookup: LookupPublicKeysFromDIDDocument,
 ) {
-    private val verifier = SdJwtVcVerifier.builder()
-        .enableIssuerMetadataResolution()
-        .enableDidResolution(lookup)
-        .build()
+    private val verifier = SdJwtVcVerifier(httpClientFactory = DefaultHttpClientFactory, didLookup = lookup)
     private val keyBindingSigner: KeyBindingSigner by lazy {
         val actualSigner = ECDSASigner(holderKey)
         object : KeyBindingSigner {
@@ -303,10 +298,7 @@ class VerifierActor(
     private val whatToDisclose: Set<String>,
     lookup: LookupPublicKeysFromDIDDocument,
 ) {
-    private val verifier = SdJwtVcVerifier.builder()
-        .enableIssuerMetadataResolution()
-        .enableDidResolution(lookup)
-        .build()
+    private val verifier = SdJwtVcVerifier(httpClientFactory = DefaultHttpClientFactory, didLookup = lookup)
     private var lastChallenge: JsonObject? = null
     private var presentation: SdJwt.Presentation<JwtAndClaims>? = null
     fun query(): VerifierQuery = VerifierQuery(

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -54,7 +54,7 @@ class KeyBindingTest {
 
     private val issuer = IssuerActor(genKey("issuer"))
     private val lookup = LookupPublicKeysFromDIDDocument { _, _ -> listOf(issuer.issuerKey.toPublicJWK()) }
-    private val verifier = SdJwtVcVerifier(httpClientFactory = DefaultHttpClientFactory, didLookup = lookup)
+    private val verifier = SdJwtVcVerifier(httpClientFactory = DefaultHttpClientFactory, lookup = lookup)
     private val holder = HolderActor(genKey("holder"), lookup)
 
     /**
@@ -239,7 +239,7 @@ class HolderActor(
     holderKey: ECKey,
     lookup: LookupPublicKeysFromDIDDocument,
 ) {
-    private val verifier = SdJwtVcVerifier(httpClientFactory = DefaultHttpClientFactory, didLookup = lookup)
+    private val verifier = SdJwtVcVerifier(httpClientFactory = DefaultHttpClientFactory, lookup = lookup)
     private val keyBindingSigner: KeyBindingSigner by lazy {
         val actualSigner = ECDSASigner(holderKey)
         object : KeyBindingSigner {
@@ -298,7 +298,7 @@ class VerifierActor(
     private val whatToDisclose: Set<String>,
     lookup: LookupPublicKeysFromDIDDocument,
 ) {
-    private val verifier = SdJwtVcVerifier(httpClientFactory = DefaultHttpClientFactory, didLookup = lookup)
+    private val verifier = SdJwtVcVerifier(httpClientFactory = DefaultHttpClientFactory, lookup = lookup)
     private var lastChallenge: JsonObject? = null
     private var presentation: SdJwt.Presentation<JwtAndClaims>? = null
     fun query(): VerifierQuery = VerifierQuery(

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -46,7 +46,7 @@ class PidDevVerificationTest : Printer {
     fun testPy() = doTest(pid2, enableLogging = false)
 
     private fun doTest(unverifiedSdJwtVc: String, enableLogging: Boolean = false) = runTest {
-        val verifier = SdJwtVcVerifier(
+        val verifier = SdJwtVcVerifier.usingIssuerMetadataOrX5c(
             httpClientFactory = { createHttpClient(enableLogging = enableLogging) },
             x509CertificateTrust = { _ -> true },
         )

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -46,10 +46,10 @@ class PidDevVerificationTest : Printer {
     fun testPy() = doTest(pid2, enableLogging = false)
 
     private fun doTest(unverifiedSdJwtVc: String, enableLogging: Boolean = false) = runTest {
-        val verifier = SdJwtVcVerifier(
-            httpClientFactory = { createHttpClient(enableLogging = enableLogging) },
-            trust = { x5c -> true },
-        )
+        val verifier = SdJwtVcVerifier.builder()
+            .enableIssuerMetadataResolution { createHttpClient(enableLogging = enableLogging) }
+            .enableX509CertificateTrust { _ -> true }
+            .build()
 
         val issuedSdJwt = try {
             val tmp = verifier.verifyIssuance(unverifiedSdJwtVc).getOrThrow()

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -46,10 +46,10 @@ class PidDevVerificationTest : Printer {
     fun testPy() = doTest(pid2, enableLogging = false)
 
     private fun doTest(unverifiedSdJwtVc: String, enableLogging: Boolean = false) = runTest {
-        val verifier = SdJwtVcVerifier.builder()
-            .enableIssuerMetadataResolution { createHttpClient(enableLogging = enableLogging) }
-            .enableX509CertificateTrust { _ -> true }
-            .build()
+        val verifier = SdJwtVcVerifier(
+            httpClientFactory = { createHttpClient(enableLogging = enableLogging) },
+            x509CertificateTrust = { _ -> true },
+        )
 
         val issuedSdJwt = try {
             val tmp = verifier.verifyIssuance(unverifiedSdJwtVc).getOrThrow()

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -46,7 +46,7 @@ class PidDevVerificationTest : Printer {
     fun testPy() = doTest(pid2, enableLogging = false)
 
     private fun doTest(unverifiedSdJwtVc: String, enableLogging: Boolean = false) = runTest {
-        val verifier = SdJwtVcVerifier.usingIssuerMetadataOrX5c(
+        val verifier = SdJwtVcVerifier.usingX5cOrIssuerMetadata(
             httpClientFactory = { createHttpClient(enableLogging = enableLogging) },
             x509CertificateTrust = { _ -> true },
         )

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -17,32 +17,65 @@ package eu.europa.ec.eudi.sdjwt.examples
 
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.crypto.Ed25519Signer
+import com.nimbusds.jose.crypto.ECDSASigner
 import com.nimbusds.jose.jwk.Curve
-import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator
+import com.nimbusds.jose.util.Base64
+import com.nimbusds.jose.util.X509CertUtils
 import eu.europa.ec.eudi.sdjwt.*
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerifier
 import kotlinx.coroutines.runBlocking
-import kotlin.io.encoding.Base64
-import kotlin.test.assertEquals
+import org.bouncycastle.asn1.DERSequence
+import org.bouncycastle.asn1.x509.Extension
+import org.bouncycastle.asn1.x509.GeneralName
+import org.bouncycastle.asn1.x509.GeneralNames
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import java.math.BigInteger
+import java.net.URL
+import java.time.Clock
+import java.util.*
+import javax.security.auth.x500.X500Principal
+import kotlin.time.Duration.Companion.days
+import kotlin.time.toJavaDuration
 
 val sdJwtVcVerification = runBlocking {
-    val key = OctetKeyPairGenerator(Curve.Ed25519).generate()
-    val didJwk = "did:jwk:${Base64.UrlSafe.encode(key.toPublicJWK().toJSONString().toByteArray())}"
+    val issuer = URL("https://issuer.example.com")
+    val key = ECKeyGenerator(Curve.P_521).generate()
+    val certificate = run {
+        val clock = Clock.systemDefaultZone()
+        val issuedAt = clock.instant()
+        val expiresAt = issuedAt + 365.days.toJavaDuration()
+        val subject = X500Principal("CN=${issuer.host}")
+        val signer = JcaContentSignerBuilder("SHA256withECDSA").build(key.toECPrivateKey())
+        val holder = JcaX509v3CertificateBuilder(
+            subject,
+            BigInteger.ONE,
+            Date.from(issuedAt),
+            Date.from(expiresAt),
+            subject,
+            key.toECPublicKey(),
+        ).addExtension(
+            Extension.subjectAlternativeName,
+            true,
+            GeneralNames.getInstance(DERSequence(GeneralName(GeneralName.dNSName, issuer.host))),
+        ).build(signer)
+        X509CertUtils.parse(holder.encoded)
+    }
 
     val sdJwt = run {
         val spec = sdJwt {
-            iss(didJwk)
+            iss(issuer.toExternalForm())
         }
-        val signer = SdJwtIssuer.nimbus(signer = Ed25519Signer(key), signAlgorithm = JWSAlgorithm.EdDSA) {
+        val signer = SdJwtIssuer.nimbus(signer = ECDSASigner(key), signAlgorithm = JWSAlgorithm.ES512) {
             type(JOSEObjectType("vc+sd-jwt"))
+            x509CertChain(listOf(Base64.encode(certificate.encoded)))
         }
         signer.issue(spec).getOrThrow()
     }
 
-    val verifier = SdJwtVcVerifier.usingDID { did, _ ->
-        assertEquals(didJwk, did)
-        listOf(key.toPublicJWK())
+    val verifier = SdJwtVcVerifier.usingX5c { chain ->
+        chain.isNotEmpty() && chain.first() == certificate
     }
 
     verifier.verifyIssuance(sdJwt.serialize())

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -25,7 +25,6 @@ import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerifier
 import kotlinx.coroutines.runBlocking
 import kotlin.io.encoding.Base64
 import kotlin.test.assertEquals
-import kotlin.test.fail
 
 val sdJwtVcVerification = runBlocking {
     val key = OctetKeyPairGenerator(Curve.Ed25519).generate()
@@ -41,9 +40,7 @@ val sdJwtVcVerification = runBlocking {
         signer.issue(spec).getOrThrow()
     }
 
-    val verifier = SdJwtVcVerifier(
-        x509CertificateTrust = { _ -> fail("X509Certificate trust should not have been used") },
-    ) { did, _ ->
+    val verifier = SdJwtVcVerifier.usingDID { did, _ ->
         assertEquals(didJwk, did)
         listOf(key.toPublicJWK())
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -41,12 +41,12 @@ val sdJwtVcVerification = runBlocking {
         signer.issue(spec).getOrThrow()
     }
 
-    val verifier = SdJwtVcVerifier.builder()
-        .enableX509CertificateTrust { _ -> fail("X509Certificate trust should not have been used") }
-        .enableDidResolution { did, _ ->
-            assertEquals(didJwk, did)
-            listOf(key.toPublicJWK())
-        }
-        .build()
+    val verifier = SdJwtVcVerifier(
+        x509CertificateTrust = { _ -> fail("X509Certificate trust should not have been used") },
+    ) { did, _ ->
+        assertEquals(didJwk, did)
+        listOf(key.toPublicJWK())
+    }
+
     verifier.verifyIssuance(sdJwt.serialize())
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -107,7 +107,13 @@ class SdJwtVcVerifierTest {
 
     @Test
     fun `keySource should return a Metadata when iss is a https url`() {
-        val expectedSource = SdJwtVcIssuerPublicKeySource.Metadata(Url("https://example.com"))
+        val expectedSource = SdJwtVcIssuerPublicKeySource.Metadata(Url("https://example.com"), null)
+        testForMetaDataSource(expectedSource)
+    }
+
+    @Test
+    fun `keySource should return a Metadata when iss is a https url and kid is provided`() {
+        val expectedSource = SdJwtVcIssuerPublicKeySource.Metadata(Url("https://example.com"), "some-kid")
         testForMetaDataSource(expectedSource)
     }
 
@@ -115,6 +121,7 @@ class SdJwtVcVerifierTest {
         val jwt = run {
             val header = JWSHeader.Builder(JWSAlgorithm.ES256).apply {
                 type(JOSEObjectType(SD_JWT_VC_TYPE))
+                expectedSource.kid?.let { keyID(it) }
             }.build()
             val payload = JWTClaimsSet.Builder().apply {
                 issuer(expectedSource.iss.toString())


### PR DESCRIPTION
1. Makes the constructor of `SdJwtVcVerifier` private
~~2. Introduces a new fluent builder instantiated via `SdJwtVcVerifier.builder()` to allow clients to enable the desired resolution strategies. As a bare minimum the builder requires either SD-JWT-VC Issuer metadata or X509 Certificate trust to be configured. DID resolution is not required and can be enabled/configured alongside any other resolution strategy.~~
2. Introduces factory methods that allow the caller to enable the desired resolution strategies.

Closes #248 