### PR TITLE
Fix signature verification of Key Binding JWTs signed using OctetKeyPairs/EdDSA

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -15,33 +15,45 @@
  */
 package eu.europa.ec.eudi.sdjwt
 
-import com.nimbusds.jose.*
-import com.nimbusds.jose.JOSEObjectType
-import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.JWSSigner
-import com.nimbusds.jose.jwk.AsymmetricJWK
-import com.nimbusds.jose.proc.SecurityContext
-import com.nimbusds.jwt.JWTClaimsSet
-import kotlinx.serialization.json.*
-import java.security.PublicKey
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
 import java.text.ParseException
 import com.nimbusds.jose.JOSEException as NimbusJOSEException
 import com.nimbusds.jose.JOSEObjectType as NimbusJOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm as NimbusJWSAlgorithm
 import com.nimbusds.jose.JWSHeader as NimbusJWSHeader
+import com.nimbusds.jose.JWSObject as NimbusJWSObject
 import com.nimbusds.jose.JWSSigner as NimbusJWSSigner
 import com.nimbusds.jose.JWSVerifier as NimbusJWSVerifier
+import com.nimbusds.jose.crypto.ECDSAVerifier as NimbusECDSAVerifier
+import com.nimbusds.jose.crypto.Ed25519Verifier as NimbusEd25519Verifier
+import com.nimbusds.jose.crypto.MACVerifier as NimbusMACVerifier
+import com.nimbusds.jose.crypto.RSASSAVerifier as NimbusRSASSAVerifier
 import com.nimbusds.jose.crypto.factories.DefaultJWSSignerFactory as NimbusDefaultJWSSignerFactory
 import com.nimbusds.jose.jwk.AsymmetricJWK as NimbusAsymmetricJWK
+import com.nimbusds.jose.jwk.ECKey as NimbusECKey
 import com.nimbusds.jose.jwk.JWK as NimbusJWK
+import com.nimbusds.jose.jwk.JWKMatcher as NimbusJWKMatcher
+import com.nimbusds.jose.jwk.JWKSelector as NimbusJWKSelector
+import com.nimbusds.jose.jwk.JWKSet as NimbusJWKSet
+import com.nimbusds.jose.jwk.OctetKeyPair as NimbusOctetKeyPair
+import com.nimbusds.jose.jwk.OctetSequenceKey as NimbusOctetSequenceKey
+import com.nimbusds.jose.jwk.RSAKey as NimbusRSAKey
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet as NimbusImmutableJWKSet
+import com.nimbusds.jose.jwk.source.JWKSource as NimbusJWKSource
+import com.nimbusds.jose.proc.BadJOSEException as NimbusBadJOSEException
 import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier as NimbusDefaultJOSEObjectTypeVerifier
-import com.nimbusds.jose.proc.JWSKeySelector as NimbusJWSKeySelector
-import com.nimbusds.jose.proc.SingleKeyJWSKeySelector as NimbusSingleKeyJWSKeySelector
+import com.nimbusds.jose.proc.JOSEObjectTypeVerifier as NimbusJOSEObjectTypeVerifier
+import com.nimbusds.jose.proc.SecurityContext as NimbusSecurityContext
+import com.nimbusds.jwt.EncryptedJWT as NimbusEncryptedJWT
 import com.nimbusds.jwt.JWT as NimbusJWT
 import com.nimbusds.jwt.JWTClaimsSet as NimbusJWTClaimsSet
+import com.nimbusds.jwt.PlainJWT as NimbusPlainJWT
 import com.nimbusds.jwt.SignedJWT as NimbusSignedJWT
+import com.nimbusds.jwt.proc.BadJWTException as NimbusBadJWTException
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier as NimbusDefaultJWTClaimsVerifier
-import com.nimbusds.jwt.proc.DefaultJWTProcessor as NimbusDefaultJWTProcessor
+import com.nimbusds.jwt.proc.JWTClaimsSetVerifier as NimbusJWTClaimsSetVerifier
 import com.nimbusds.jwt.proc.JWTProcessor as NimbusJWTProcessor
 
 //
@@ -90,9 +102,9 @@ fun KeyBindingVerifier.Companion.mustBePresentAndValid(
 ): KeyBindingVerifier.MustBePresentAndValid {
     val keyBindingVerifierProvider: (Claims) -> JwtSignatureVerifier = { sdJwtClaims ->
         holderPubKeyExtractor(sdJwtClaims)?.let { holderPubKey ->
-            val key = holderPubKey.toPublicKey()
             val challengeClaimSet: NimbusJWTClaimsSet = NimbusJWTClaimsSet.parse(challenge.toString())
-            keyBindingJWTProcess(key, challengeClaimSet).asJwtVerifier()
+            check(holderPubKey is NimbusJWK)
+            keyBindingJWTProcess(holderPubKey, challengeClaimSet).asJwtVerifier()
         } ?: throw KeyBindingError.MissingHolderPubKey.asException()
     }
     return KeyBindingVerifier.MustBePresentAndValid(keyBindingVerifierProvider)
@@ -112,23 +124,18 @@ fun KeyBindingVerifier.Companion.mustBePresentAndValid(
  * If provided, Key Binding JWT payload should contain the challenge as is.
  * @return
  */
-fun keyBindingJWTProcess(
-    holderPubKey: PublicKey,
+internal fun <PubKey> keyBindingJWTProcess(
+    holderPubKey: PubKey,
     challenge: NimbusJWTClaimsSet? = null,
-): NimbusJWTProcessor<SecurityContext> =
-    NimbusDefaultJWTProcessor<SecurityContext>().apply {
-        jwsTypeVerifier = NimbusDefaultJOSEObjectTypeVerifier(NimbusJOSEObjectType("kb+jwt"))
-        jwsKeySelector = NimbusJWSKeySelector { header, context ->
-            val algorithm = header.algorithm
-            val nestedSelector =
-                NimbusSingleKeyJWSKeySelector<SecurityContext>(algorithm, holderPubKey)
-            nestedSelector.selectJWSKeys(header, context)
-        }
-        jwtClaimsSetVerifier = NimbusDefaultJWTClaimsVerifier(
+): NimbusJWTProcessor<NimbusSecurityContext> where PubKey : NimbusJWK, PubKey : NimbusAsymmetricJWK =
+    JwkSourceJWTProcessor(
+        typeVerifier = NimbusDefaultJOSEObjectTypeVerifier(NimbusJOSEObjectType("kb+jwt")),
+        claimSetVerifier = NimbusDefaultJWTClaimsVerifier(
             challenge ?: NimbusJWTClaimsSet.Builder().build(),
             setOf("aud", "iat", "nonce"),
-        )
-    }
+        ),
+        jwkSource = NimbusImmutableJWKSet(NimbusJWKSet(listOf(holderPubKey))),
+    )
 
 /**
  * This is a dual of [cnf] function
@@ -334,10 +341,10 @@ fun <JWT : NimbusJWT> SdJwt<JWT>.serialize(): String =
 /**
  * Representation of a function used to sign the Keybinding JWT of a Presentation SD-JWT.
  */
-interface KeyBindingSigner : JWSSigner {
-    val signAlgorithm: JWSAlgorithm
-    val publicKey: AsymmetricJWK
-    override fun supportedJWSAlgorithms(): MutableSet<JWSAlgorithm> = mutableSetOf(signAlgorithm)
+interface KeyBindingSigner : NimbusJWSSigner {
+    val signAlgorithm: NimbusJWSAlgorithm
+    val publicKey: NimbusAsymmetricJWK
+    override fun supportedJWSAlgorithms(): MutableSet<NimbusJWSAlgorithm> = mutableSetOf(signAlgorithm)
 }
 
 /**
@@ -355,7 +362,7 @@ interface KeyBindingSigner : JWSSigner {
 fun <JWT : NimbusJWT> SdJwt.Presentation<JWT>.serializeWithKeyBinding(
     hashAlgorithm: HashAlgorithm,
     keyBindingSigner: KeyBindingSigner,
-    claimSetBuilderAction: JWTClaimsSet.Builder.() -> Unit,
+    claimSetBuilderAction: NimbusJWTClaimsSet.Builder.() -> Unit,
 ): String =
     serializeWithKeyBinding(NimbusJWT::serialize, hashAlgorithm, keyBindingSigner, claimSetBuilderAction)
 
@@ -374,7 +381,7 @@ fun <JWT : NimbusJWT> SdJwt.Presentation<JWT>.serializeWithKeyBinding(
 fun <JWT : NimbusJWT> SdJwt.Presentation<JWT>.serializeWithKeyBindingAsJwsJson(
     hashAlgorithm: HashAlgorithm,
     keyBindingSigner: KeyBindingSigner,
-    claimSetBuilderAction: JWTClaimsSet.Builder.() -> Unit,
+    claimSetBuilderAction: NimbusJWTClaimsSet.Builder.() -> Unit,
 ): JsonObject =
     serializeWithKeyBindingAsJwsJson(NimbusJWT::serialize, hashAlgorithm, keyBindingSigner, claimSetBuilderAction)
 
@@ -395,7 +402,7 @@ fun <JWT> SdJwt.Presentation<JWT>.serializeWithKeyBinding(
     jwtSerializer: (JWT) -> String,
     hashAlgorithm: HashAlgorithm,
     keyBindingSigner: KeyBindingSigner,
-    claimSetBuilderAction: JWTClaimsSet.Builder.() -> Unit,
+    claimSetBuilderAction: NimbusJWTClaimsSet.Builder.() -> Unit,
 ): String {
     val (presentationSdJwt, kbJwt) = serializedAndKeyBinding(
         jwtSerializer,
@@ -424,7 +431,7 @@ internal fun <JWT> SdJwt.Presentation<JWT>.serializedAndKeyBinding(
     jwtSerializer: (JWT) -> String,
     hashAlgorithm: HashAlgorithm,
     keyBindingSigner: KeyBindingSigner,
-    claimSetBuilderAction: JWTClaimsSet.Builder.() -> Unit,
+    claimSetBuilderAction: NimbusJWTClaimsSet.Builder.() -> Unit,
 ): Pair<String, Jwt> {
     // Serialize the presentation SD-JWT with no Key binding
     val presentationSdJwt = serialize(jwtSerializer)
@@ -438,18 +445,18 @@ internal fun <JWT> SdJwt.Presentation<JWT>.serializedAndKeyBinding(
 
 internal fun kbJwt(
     keyBindingSigner: KeyBindingSigner,
-    claimSetBuilderAction: JWTClaimsSet.Builder.() -> Unit,
+    claimSetBuilderAction: NimbusJWTClaimsSet.Builder.() -> Unit,
     sdJwtDigest: SdJwtDigest,
 ): NimbusJWT {
     val header = with(NimbusJWSHeader.Builder(keyBindingSigner.signAlgorithm)) {
-        type(JOSEObjectType("kb+jwt"))
+        type(NimbusJOSEObjectType("kb+jwt"))
         val pk = keyBindingSigner.publicKey
         if (pk is NimbusJWK) {
             keyID(pk.keyID)
         }
         build()
     }
-    val claimSet = with(JWTClaimsSet.Builder()) {
+    val claimSet = with(NimbusJWTClaimsSet.Builder()) {
         claimSetBuilderAction()
         claim(SdJwtDigest.CLAIM_NAME, sdJwtDigest.value)
         build()
@@ -479,7 +486,7 @@ fun <JWT> SdJwt.Presentation<JWT>.serializeWithKeyBindingAsJwsJson(
     jwtSerializer: (JWT) -> String,
     hashAlgorithm: HashAlgorithm,
     keyBindingSigner: KeyBindingSigner,
-    claimSetBuilderAction: JWTClaimsSet.Builder.() -> Unit,
+    claimSetBuilderAction: NimbusJWTClaimsSet.Builder.() -> Unit,
     option: JwsSerializationOption = JwsSerializationOption.Flattened,
 ): JsonObject {
     val (presentationSdJwt, kbJwt) = serializedAndKeyBinding(
@@ -520,7 +527,7 @@ fun SdJwt<NimbusSignedJWT>.serializeAsJwsJson(
     option: JwsSerializationOption = JwsSerializationOption.Flattened,
 ): JsonObject {
     return asJwsJsonObject(option, kbJwt = null) { jwt ->
-        require(jwt.state == JWSObject.State.SIGNED || jwt.state == JWSObject.State.VERIFIED) {
+        require(jwt.state == NimbusJWSObject.State.SIGNED || jwt.state == NimbusJWSObject.State.VERIFIED) {
             "It seems that the jwt is not signed"
         }
         Triple(
@@ -580,3 +587,66 @@ fun SdJwt.Issuance<NimbusSignedJWT>.present(query: Set<JsonPointer>): SdJwt.Pres
  */
 fun SdJwt.Issuance<NimbusSignedJWT>.present(query: (JsonPointer) -> Boolean): SdJwt.Presentation<NimbusSignedJWT>? =
     present(query) { it.jwtClaimsSet.asClaims() }
+
+internal open class JwkSourceJWTProcessor<C : NimbusSecurityContext>(
+    private val typeVerifier: NimbusJOSEObjectTypeVerifier<C>? = null,
+    private val claimSetVerifier: NimbusJWTClaimsSetVerifier<C>? = null,
+    private val jwkSource: NimbusJWKSource<C>,
+) : NimbusJWTProcessor<C> {
+
+    private fun notSupported(): Nothing = throw RuntimeException("Operation not supported")
+    override fun process(jwtString: String?, context: C?): NimbusJWTClaimsSet? = notSupported()
+    override fun process(jwt: NimbusJWT?, context: C?): NimbusJWTClaimsSet? = notSupported()
+    override fun process(plainJWT: NimbusPlainJWT?, context: C?): NimbusJWTClaimsSet? = notSupported()
+    override fun process(encryptedJWT: NimbusEncryptedJWT?, context: C?): NimbusJWTClaimsSet? = notSupported()
+
+    override fun process(signedJWT: NimbusSignedJWT, context: C?): NimbusJWTClaimsSet {
+        typeVerifier?.verify(signedJWT.header.type, context)
+
+        val claimsSet = signedJWT.jwtClaimSet()
+        val jwkSelector = NimbusJWKSelector(NimbusJWKMatcher.forJWSHeader(signedJWT.header))
+
+        val jwks = jwkSource.get(jwkSelector, context)
+        if (jwks.isNullOrEmpty()) {
+            throw NimbusBadJOSEException("Signed JWT rejected: Another algorithm expected, or no matching key(s) found")
+        }
+
+        for (jwk in jwks) {
+            val verifier = jwsVerifierFor(signedJWT.header.algorithm, jwk)
+            if (signedJWT.verify(verifier)) {
+                claimSetVerifier?.verify(claimsSet, context)
+                return claimsSet
+            }
+        }
+
+        // No more keys to try out
+        throw NimbusBadJOSEException("Signed JWT rejected: Invalid signature or no matching verifier(s) found")
+    }
+
+    companion object {
+
+        private fun NimbusSignedJWT.jwtClaimSet(): NimbusJWTClaimsSet =
+            try {
+                getJWTClaimsSet()
+            } catch (e: ParseException) {
+                // Payload not a JSON object
+                throw NimbusBadJWTException(e.message, e)
+            }
+
+        private fun jwsVerifierFor(algorithm: NimbusJWSAlgorithm, jwk: NimbusJWK): NimbusJWSVerifier =
+            when (algorithm) {
+                in NimbusJWSAlgorithm.Family.HMAC_SHA -> NimbusMACVerifier(jwk.expectIs<NimbusOctetSequenceKey>())
+                in NimbusJWSAlgorithm.Family.RSA -> NimbusRSASSAVerifier(jwk.expectIs<NimbusRSAKey>())
+                in NimbusJWSAlgorithm.Family.EC -> NimbusECDSAVerifier(jwk.expectIs<NimbusECKey>())
+                in NimbusJWSAlgorithm.Family.ED -> NimbusEd25519Verifier(jwk.expectIs<NimbusOctetKeyPair>())
+                else -> throw NimbusBadJOSEException("Unsupported JWS algorithm $algorithm")
+            }
+
+        private inline fun <reified T> NimbusJWK.expectIs(): T =
+            if (this is T) {
+                this
+            } else {
+                throw NimbusBadJOSEException("Expected a JWK of type ${T::class.java.simpleName}")
+            }
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcJwtProcessor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcJwtProcessor.kt
@@ -19,25 +19,20 @@ import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.JWSVerifier
-import com.nimbusds.jose.crypto.ECDSAVerifier
-import com.nimbusds.jose.crypto.Ed25519Verifier
-import com.nimbusds.jose.crypto.MACVerifier
-import com.nimbusds.jose.crypto.RSASSAVerifier
 import com.nimbusds.jose.crypto.factories.DefaultJWSVerifierFactory
 import com.nimbusds.jose.jwk.*
 import com.nimbusds.jose.jwk.source.JWKSource
-import com.nimbusds.jose.proc.BadJOSEException
 import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier
+import com.nimbusds.jose.proc.JOSEObjectTypeVerifier
 import com.nimbusds.jose.proc.JWSVerificationKeySelector
 import com.nimbusds.jose.proc.SecurityContext
 import com.nimbusds.jwt.JWTClaimsSet
-import com.nimbusds.jwt.SignedJWT
-import com.nimbusds.jwt.proc.BadJWTException
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier
 import com.nimbusds.jwt.proc.DefaultJWTProcessor
+import com.nimbusds.jwt.proc.JWTClaimsSetVerifier
 import com.nimbusds.jwt.proc.JWTProcessor
+import eu.europa.ec.eudi.sdjwt.JwkSourceJWTProcessor
 import java.security.Key
-import java.text.ParseException
 
 const val SD_JWT_VC_TYPE = "vc+sd-jwt"
 
@@ -56,83 +51,25 @@ const val SD_JWT_VC_TYPE = "vc+sd-jwt"
  * **Note:** The optional dependency 'com.google.crypto.tink:tink' is required when support for [OctetKeyPair] is required.
  */
 internal class SdJwtVcJwtProcessor<C : SecurityContext>(
-    private val jwkSource: JWKSource<C>,
-) : DefaultJWTProcessor<C>() {
-    init {
-        jwsTypeVerifier = DefaultJOSEObjectTypeVerifier(JOSEObjectType(SD_JWT_VC_TYPE))
-        jwtClaimsSetVerifier = DefaultJWTClaimsVerifier(
+    jwkSource: JWKSource<C>,
+) : JwkSourceJWTProcessor<C>(typeVerifier(), claimSetVerifier(), jwkSource) {
+
+    companion object {
+        private fun <C : SecurityContext> typeVerifier(): JOSEObjectTypeVerifier<C> =
+            DefaultJOSEObjectTypeVerifier(JOSEObjectType(SD_JWT_VC_TYPE))
+
+        private fun <C : SecurityContext> claimSetVerifier(): JWTClaimsSetVerifier<C> = DefaultJWTClaimsVerifier(
             JWTClaimsSet.Builder().build(),
             setOf("iss"),
         )
-    }
-
-    override fun process(signedJWT: SignedJWT, context: C?): JWTClaimsSet {
-        ensureInitialized()
-
-        jwsTypeVerifier.verify(signedJWT.header.type, context)
-
-        val claimsSet = signedJWT.jwtClaimSet()
-        val jwkSelector = JWKSelector(JWKMatcher.forJWSHeader(signedJWT.header))
-
-        val jwks = jwkSource.get(jwkSelector, context)
-        if (jwks.isNullOrEmpty()) {
-            throw BadJOSEException("Signed JWT rejected: Another algorithm expected, or no matching key(s) found")
-        }
-
-        for (jwk in jwks) {
-            val verifier = jwsVerifierFor(signedJWT.header.algorithm, jwk)
-            if (signedJWT.verify(verifier)) {
-                jwtClaimsSetVerifier.verify(claimsSet, context)
-                return claimsSet
-            }
-        }
-
-        // No more keys to try out
-        throw BadJOSEException("Signed JWT rejected: Invalid signature or no matching verifier(s) found")
-    }
-
-    private fun ensureInitialized() {
-        if (jwsTypeVerifier == null) {
-            throw BadJOSEException("Signed JWT rejected: No JWS header typ (type) verifier is configured")
-        }
-
-        if (jwtClaimsSetVerifier == null) {
-            throw BadJOSEException("Signed JWT rejected: No JWTClaimSet verifier is configured")
-        }
-    }
-
-    companion object {
 
         /**
          * Gets a [JWKSource] for a DID Document.
          */
-        fun <C : SecurityContext> didJwkSet(jwsHeader: JWSHeader, jwkSet: JWKSet): JWKSource<C> = DIDJWKSet<C>(jwsHeader, jwkSet)
+        fun <C : SecurityContext> didJwkSet(jwsHeader: JWSHeader, jwkSet: JWKSet): JWKSource<C> =
+            DIDJWKSet<C>(jwsHeader, jwkSet)
     }
 }
-
-private fun SignedJWT.jwtClaimSet(): JWTClaimsSet =
-    try {
-        getJWTClaimsSet()
-    } catch (e: ParseException) {
-        // Payload not a JSON object
-        throw BadJWTException(e.message, e)
-    }
-
-private fun jwsVerifierFor(algorithm: JWSAlgorithm, jwk: JWK): JWSVerifier =
-    when (algorithm) {
-        in JWSAlgorithm.Family.HMAC_SHA -> MACVerifier(jwk.expectIs<OctetSequenceKey>())
-        in JWSAlgorithm.Family.RSA -> RSASSAVerifier(jwk.expectIs<RSAKey>())
-        in JWSAlgorithm.Family.EC -> ECDSAVerifier(jwk.expectIs<ECKey>())
-        in JWSAlgorithm.Family.ED -> Ed25519Verifier(jwk.expectIs<OctetKeyPair>())
-        else -> throw BadJOSEException("Unsupported JWS algorithm $algorithm")
-    }
-
-private inline fun <reified T> JWK.expectIs(): T =
-    if (this is T) {
-        this
-    } else {
-        throw BadJOSEException("Expected a JWK of type ${T::class.java.simpleName}")
-    }
 
 /**
  * [JWKSource] implementation for DID Documents.
@@ -153,6 +90,7 @@ private class DIDJWKSet<C : SecurityContext>(jwsHeader: JWSHeader, val jwkSet: J
                     .algorithms(algorithm, null)
                     .x509CertSHA256Thumbprint(jwsHeader.x509CertSHA256Thumbprint)
                     .build()
+
             in JWSAlgorithm.Family.ED ->
                 JWKMatcher.Builder()
                     .keyType(KeyType.forAlgorithm(algorithm))
@@ -160,6 +98,7 @@ private class DIDJWKSet<C : SecurityContext>(jwsHeader: JWSHeader, val jwkSet: J
                     .algorithms(algorithm, null)
                     .curves(Curve.forJWSAlgorithm(algorithm))
                     .build()
+
             else -> error("Unsupported JWSAlgorithm '$algorithm'")
         }
         JWKSelector(matcher)


### PR DESCRIPTION
Creates a new common `JWTProcessor` implementation that can be used both for Key Binding JWT and SD-JWT-VC signature verification.

Closes #245 