### PR TITLE
API improvements (KMP friendly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,12 +254,13 @@ import com.nimbusds.jose.*
 import com.nimbusds.jose.crypto.*
 import com.nimbusds.jose.jwk.*
 import eu.europa.ec.eudi.sdjwt.*
+import eu.europa.ec.eudi.sdjwt.jsonObject
 import kotlinx.serialization.json.*
 import com.nimbusds.jwt.SignedJWT as NimbusSignedJWT
 -->
 
 ```kotlin
-val claims: Claims = run {
+val claims: JsonObject = run {
     val issuerKeyPair: RSAKey = loadRsaKey("/examplesIssuerKey.json")
     val sdJwt: SdJwt.Issuance<NimbusSignedJWT> =
         signedSdJwt(signer = RSASSASigner(issuerKeyPair), signAlgorithm = JWSAlgorithm.RS256) {
@@ -278,7 +279,7 @@ val claims: Claims = run {
                 }
             }
         }
-    sdJwt.recreateClaims { jwt -> jwt.jwtClaimsSet.asClaims() }
+    sdJwt.recreateClaims { jwt -> jwt.jwtClaimsSet.jsonObject() }
 }
 ```
 

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Deprecated.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Deprecated.kt
@@ -16,6 +16,9 @@
 package eu.europa.ec.eudi.sdjwt
 
 import eu.europa.ec.eudi.sdjwt.vc.toJsonPointer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import com.nimbusds.jwt.JWTClaimsSet as NimbusJWTClaimsSet
 import com.nimbusds.jwt.SignedJWT as NimbusSignedJWT
 
 /**
@@ -51,13 +54,14 @@ fun SdJwt.Issuance<JwtAndClaims>.present(
 @JvmName("presentMatching")
 fun SdJwt.Issuance<JwtAndClaims>.present(
     query: Set<JsonPointer>,
-): SdJwt.Presentation<JwtAndClaims>? = presentJsonPointersMatching({ pointer: JsonPointer -> pointer in query }) { (_, claims) -> claims }
+): SdJwt.Presentation<JwtAndClaims>? =
+    presentJsonPointersMatching({ pointer: JsonPointer -> pointer in query }) { (_, claims) -> claims }
 
 /**
  * Tries to create a presentation that discloses the claims are in [query]
  * @param query a set of [JsonPointer] relative to the unprotected JSON (not the JWT payload). Pointers for
  * claims that are always disclosable can be omitted
- * @param claimsOf a function to obtain the [Claims] of the [SdJwt.jwt]
+ * @param claimsOf a function to obtain the claims of the [SdJwt.jwt]
  * @receiver The issuance SD-JWT upon which the presentation will be based
  * @param JWT the type representing the JWT part of the SD-JWT
  * @return the presentation if possible to satisfy the [query]
@@ -70,7 +74,7 @@ fun SdJwt.Issuance<JwtAndClaims>.present(
 @JvmName("presentMatchingSetOfPointers")
 fun <JWT> SdJwt.Issuance<JWT>.present(
     query: Set<JsonPointer>,
-    claimsOf: (JWT) -> Claims,
+    claimsOf: (JWT) -> JsonObject,
 ): SdJwt.Presentation<JWT>? =
     presentJsonPointersMatching({ pointer: JsonPointer -> pointer in query }, claimsOf)
 
@@ -79,7 +83,7 @@ fun <JWT> SdJwt.Issuance<JWT>.present(
  * [query]
  * @param query a predicate for the claims to include in the presentation. The [JsonPointer]
  * is relative to the unprotected JSON (not the JWT payload)
- * @param claimsOf a function to obtain the [Claims] of the [SdJwt.jwt]
+ * @param claimsOf a function to obtain the claims of the [SdJwt.jwt]
  * @receiver The issuance SD-JWT upon which the presentation will be based
  * @param JWT the type representing the JWT part of the SD-JWT
  * @return the presentation if possible to satisfy the [query]
@@ -92,7 +96,7 @@ fun <JWT> SdJwt.Issuance<JWT>.present(
 @JvmName("presentMatching")
 fun <JWT> SdJwt.Issuance<JWT>.present(
     query: (JsonPointer) -> Boolean,
-    claimsOf: (JWT) -> Claims,
+    claimsOf: (JWT) -> JsonObject,
 ): SdJwt.Presentation<JWT>? =
     presentJsonPointersMatching(query, claimsOf)
 
@@ -143,14 +147,14 @@ fun SdJwt.Issuance<NimbusSignedJWT>.present(query: (JsonPointer) -> Boolean): Sd
     level = DeprecationLevel.WARNING,
 )
 fun SdJwt.Issuance<NimbusSignedJWT>.presentJsonPointersMatching(query: (JsonPointer) -> Boolean): SdJwt.Presentation<NimbusSignedJWT>? =
-    presentJsonPointersMatching(query) { it.jwtClaimsSet.asClaims() }
+    presentJsonPointersMatching(query) { it.jwtClaimsSet.jsonObject() }
 
 /**
  * Tries to create a presentation that discloses the claims that satisfy
  * [query]
  * @param query a predicate for the claims to include in the presentation. The [JsonPointer]
  * is relative to the unprotected JSON (not the JWT payload)
- * @param claimsOf a function to obtain the [Claims] of the [SdJwt.jwt]
+ * @param claimsOf a function to obtain the claims of the [SdJwt.jwt]
  * @receiver The issuance SD-JWT upon which the presentation will be based
  * @param JWT the type representing the JWT part of the SD-JWT
  * @return the presentation if possible to satisfy the [query]
@@ -161,7 +165,7 @@ fun SdJwt.Issuance<NimbusSignedJWT>.presentJsonPointersMatching(query: (JsonPoin
 )
 fun <JWT> SdJwt.Issuance<JWT>.presentJsonPointersMatching(
     query: (JsonPointer) -> Boolean,
-    claimsOf: (JWT) -> Claims,
+    claimsOf: (JWT) -> JsonObject,
 ): SdJwt.Presentation<JWT>? {
     val disclosuresPerClaim = recreateClaimsAndDisclosuresPerClaim(claimsOf)
         .second
@@ -186,3 +190,24 @@ fun <JWT> SdJwt.Issuance<JWT>.presentJsonPointersMatching(
     level = DeprecationLevel.WARNING,
 )
 typealias DisclosuresPerClaim = Map<JsonPointer, List<Disclosure>>
+
+/**
+ * Representations of multiple claims
+ *
+ */
+@Deprecated(
+    message = "Deprecated and will be removed in a future version",
+    replaceWith = ReplaceWith("JsonObject"),
+    level = DeprecationLevel.WARNING,
+)
+typealias Claims = Map<String, JsonElement>
+
+/**
+ * An adapter that transforms the [payload][NimbusJWTClaimsSet] of a [Nimbus JWT][NimbusJWT]
+ * to a KotlinX Serialization compatible representation
+ */
+@Deprecated(
+    message = "Deprecated and will be removed in a future release",
+    replaceWith = ReplaceWith("jsonObject()"),
+)
+fun NimbusJWTClaimsSet.asClaims(): JsonObject = jsonObject()

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Dsl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Dsl.kt
@@ -323,7 +323,7 @@ fun SdObjectBuilder.sd(name: String, element: SdObjectElement) = put(name, eleme
 fun SdObjectBuilder.sd(name: String, value: String) = sd(name, JsonPrimitive(value))
 fun SdObjectBuilder.sd(name: String, value: Number) = sd(name, JsonPrimitive(value))
 fun SdObjectBuilder.sd(name: String, value: Boolean) = sd(name, JsonPrimitive(value))
-fun SdObjectBuilder.sd(obj: Claims) = obj.forEach { (k, v) -> sd(k, v) }
+fun SdObjectBuilder.sd(obj: JsonObject) = obj.forEach { (k, v) -> sd(k, v) }
 
 /**
  * Adds into an [SdObject] an element [claims] that will be translated into a
@@ -377,7 +377,7 @@ fun SdObjectBuilder.sd(action: SdOrPlainJsonObjectBuilder.() -> Unit) = sd(build
 fun SdObjectBuilder.plain(name: String, value: String) = plain(name, JsonPrimitive(value))
 fun SdObjectBuilder.plain(name: String, value: Number) = plain(name, JsonPrimitive(value))
 fun SdObjectBuilder.plain(name: String, value: Boolean) = plain(name, JsonPrimitive(value))
-fun SdObjectBuilder.plain(obj: Claims) = obj.forEach { (k, v) -> plain(k, v) }
+fun SdObjectBuilder.plain(obj: JsonObject) = obj.forEach { (k, v) -> plain(k, v) }
 
 /**
  * Adds into an [SdObject] an element [claims] that will be translated into a

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -79,16 +79,6 @@ val JwtSignatureVerifier.Companion.NoSignatureValidation: JwtSignatureVerifier b
 }
 
 /**
- * Declares a [KeyBindingVerifier] that just makes sure that the Key Binding JWT is present, and it's indeed a JWT
- * without performing signature validation
- *
- * <em>Should not be used in production</em>
- */
-val KeyBindingVerifier.Companion.MustBePresent: KeyBindingVerifier.MustBePresentAndValid by lazy {
-    KeyBindingVerifier.MustBePresentAndValid { JwtSignatureVerifier.NoSignatureValidation }
-}
-
-/**
  * Factory method for creating a [KeyBindingVerifier] which applies the rules described in [keyBindingJWTProcess].
  * @param holderPubKeyExtractor a function that extracts the holder's public key from the payload of the SD-JWT.
  * If not provided, it is assumed that the SD-JWT issuer used the confirmation claim (see [cnf]) for this purpose.

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -67,7 +67,7 @@ import com.nimbusds.jwt.proc.JWTProcessor as NimbusJWTProcessor
  *
  * <em>Should not be used in production use cases</em>
  */
-val JwtSignatureVerifier.Companion.NoSignatureValidation: JwtSignatureVerifier by lazy {
+internal val PlatformJwtSignatureVerifierNoSignatureValidation: JwtSignatureVerifier by lazy {
     JwtSignatureVerifier { unverifiedJwt ->
         try {
             val parsedJwt = NimbusSignedJWT.parse(unverifiedJwt)

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -187,13 +187,14 @@ fun NimbusJWTProcessor<*>.asJwtVerifier(): JwtSignatureVerifier = JwtSignatureVe
  * wants to just re-obtain an instance of the [SdJwt.Issuance] without repeating this verification
  *
  */
-fun SdJwt.Companion.unverifiedIssuanceFrom(unverifiedSdJwt: String): Result<SdJwt.Issuance<JwtAndClaims>> =
+internal val PlatformSdJwtUnverifiedIssuanceFrom: UnverifiedIssuanceFrom = UnverifiedIssuanceFrom { unverifiedSdJwt ->
     runCatching {
         val (unverifiedJwt, unverifiedDisclosures) = StandardSerialization.parseIssuance(unverifiedSdJwt)
         verifyIssuance(unverifiedJwt, unverifiedDisclosures) {
             NimbusSignedJWT.parse(unverifiedJwt).jwtClaimsSet.jsonObject()
         }.getOrThrow()
     }
+}
 
 //
 // JSON Support

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtFactory.kt
@@ -68,7 +68,7 @@ class SdJwtFactory(
         val encodedClaims = mutableMapOf<String, JsonElement>()
 
         // Add the given claim to encodedClaims
-        fun add(encodedClaim: Claims) {
+        fun add(encodedClaim: JsonObject) {
             val mergedSdClaim = JsonArray(encodedClaims.sdClaim() + encodedClaim.sdClaim())
             encodedClaims += encodedClaim
             if (mergedSdClaim.isNotEmpty()) {
@@ -175,7 +175,7 @@ class SdJwtFactory(
     /**
      * Adds the hash algorithm claim if disclosures are present
      * @param h the hash algorithm
-     * @return a new [EncodedSdElement] with an updated [Claims] to
+     * @return a new [EncodedSdElement] with an updated claims to
      * contain the hash algorithm claim, if disclosures are present
      */
     private fun EncodedSdElement.addHashAlgClaim(h: HashAlgorithm): EncodedSdElement {
@@ -201,7 +201,7 @@ class SdJwtFactory(
         if (isEmpty()) JsonObject(emptyMap())
         else JsonObject(mapOf(SdJwtSpec.CLAIM_SD to JsonArray(map { JsonPrimitive(it.value) })))
 
-    private fun Claims.sdClaim(): List<JsonElement> = this[SdJwtSpec.CLAIM_SD]?.jsonArray ?: emptyList()
+    private fun Map<String, JsonElement>.sdClaim(): List<JsonElement> = this[SdJwtSpec.CLAIM_SD]?.jsonArray ?: emptyList()
 
     private fun DisclosureDigest.asDigestClaim(): JsonObject {
         return JsonObject(mapOf(SdJwtSpec.CLAIM_ARRAY_ELEMENT_DIGEST to JsonPrimitive(value)))

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtIssuer.kt
@@ -25,14 +25,9 @@ typealias SignSdJwt<SIGNED_JWT> = (UnsignedSdJwt) -> SdJwt.Issuance<SIGNED_JWT>
 /**
  * Representation of a function capable of producing an [issuance SD-JWT][SdJwt.Issuance]
  *
- * @param sdJwtFactory factory for unsigned SD-JWT
- * @param signSdJwt signer
  * @param SIGNED_JWT the type representing the JWT part of the SD-JWT, signed
  */
-class SdJwtIssuer<out SIGNED_JWT>(
-    private val sdJwtFactory: SdJwtFactory,
-    private val signSdJwt: SignSdJwt<SIGNED_JWT>,
-) {
+fun interface SdJwtIssuer<out SIGNED_JWT> {
 
     /**
      * Issues an SD-JWT
@@ -40,10 +35,22 @@ class SdJwtIssuer<out SIGNED_JWT>(
      * @param sdElements the contents of the SD-JWT
      * @return the issuance SD-JWT
      */
-    fun issue(sdElements: SdObject): Result<SdJwt.Issuance<SIGNED_JWT>> = runCatching {
-        val unsignedSdJwt = sdJwtFactory.createSdJwt(sdElements).getOrThrow()
-        signSdJwt(unsignedSdJwt)
-    }
+    fun issue(sdElements: SdObject): Result<SdJwt.Issuance<SIGNED_JWT>>
 
-    companion object
+    companion object {
+        /**
+         * Factory method
+         * @param sdJwtFactory factory for unsigned SD-JWT
+         * @param signSdJwt signer
+         */
+        operator fun <SIGNED_JWT> invoke(
+            sdJwtFactory: SdJwtFactory,
+            signSdJwt: SignSdJwt<SIGNED_JWT>,
+        ): SdJwtIssuer<SIGNED_JWT> = SdJwtIssuer { sdElements ->
+            runCatching {
+                val unsignedSdJwt = sdJwtFactory.createSdJwt(sdElements).getOrThrow()
+                signSdJwt(unsignedSdJwt)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtIssuer.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtIssuer.kt
@@ -29,7 +29,7 @@ typealias SignSdJwt<SIGNED_JWT> = (UnsignedSdJwt) -> SdJwt.Issuance<SIGNED_JWT>
  * @param signSdJwt signer
  * @param SIGNED_JWT the type representing the JWT part of the SD-JWT, signed
  */
-class SdJwtIssuer<SIGNED_JWT>(
+class SdJwtIssuer<out SIGNED_JWT>(
     private val sdJwtFactory: SdJwtFactory,
     private val signSdJwt: SignSdJwt<SIGNED_JWT>,
 ) {

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtPresent.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtPresent.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.sdjwt
 
 import eu.europa.ec.eudi.sdjwt.vc.ClaimPath
+import kotlinx.serialization.json.JsonObject
 
 /**
  * Represents a map which contains all the claims - selectively disclosable or not -
@@ -28,12 +29,12 @@ typealias DisclosuresPerClaimPath = Map<ClaimPath, List<Disclosure>>
 /**
  * Recreates the claims, used to produce the SD-JWT and at the same time calculates [DisclosuresPerClaim]
  *
- * @param claimsOf a function to obtain the [Claims] of the [SdJwt.jwt]
+ * @param claimsOf a function to obtain the claims of the [SdJwt.jwt]
  * @param JWT the type representing the JWT part of the SD-JWT
  *
  * @see SdJwt.recreateClaims
  */
-fun <JWT> SdJwt<JWT>.recreateClaimsAndDisclosuresPerClaim(claimsOf: (JWT) -> Claims): Pair<Claims, DisclosuresPerClaimPath> {
+fun <JWT> SdJwt<JWT>.recreateClaimsAndDisclosuresPerClaim(claimsOf: (JWT) -> JsonObject): Pair<JsonObject, DisclosuresPerClaimPath> {
     val disclosuresPerClaim = mutableMapOf<ClaimPath, List<Disclosure>>()
     val visitor = ClaimVisitor { path, disclosure ->
         if (disclosure != null) {
@@ -56,14 +57,14 @@ fun <JWT> SdJwt<JWT>.recreateClaimsAndDisclosuresPerClaim(claimsOf: (JWT) -> Cla
  * Tries to create a presentation that discloses the [requested claims][query].
  * @param query a set of [ClaimPaths][ClaimPath] to include in the presentation. The [ClaimPaths][ClaimPath]
  * are relative to the unprotected JSON (not the JWT payload)
- * @param claimsOf a function to obtain the [Claims] of the [SdJwt.jwt]
+ * @param claimsOf a function to obtain the claims of the [SdJwt.jwt]
  * @receiver The issuance SD-JWT upon which the presentation will be based
  * @param JWT the type representing the JWT part of the SD-JWT
  * @return the presentation if possible to satisfy the [query]
  */
 fun <JWT> SdJwt.Issuance<JWT>.present(
     query: Set<ClaimPath>,
-    claimsOf: (JWT) -> Claims,
+    claimsOf: (JWT) -> JsonObject,
 ): SdJwt.Presentation<JWT>? {
     val (_, disclosuresPerClaim) = recreateClaimsAndDisclosuresPerClaim(claimsOf)
     infix fun ClaimPath.matches(other: ClaimPath): Boolean = (value.size == other.value.size) && (this in other)

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtSerialization.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtSerialization.kt
@@ -155,7 +155,7 @@ internal object JwsJsonSupport {
      * @return the jwt and the disclosures (unverified).
      * @throws IllegalArgumentException if the given JSON Object is not compliant
      */
-    fun parseJWSJson(unverifiedSdJwt: Claims): Triple<Jwt, List<String>, Jwt?> {
+    fun parseJWSJson(unverifiedSdJwt: JsonObject): Triple<Jwt, List<String>, Jwt?> {
         fun JsonElement.stringContentOrNull() = if (this is JsonPrimitive && isString) contentOrNull else null
 
         // selects the JsonObject that contains the pair of "protected" & "signature" claims

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
@@ -224,6 +224,15 @@ sealed interface KeyBindingVerifier {
         KeyBindingVerifier
 
     companion object {
+        /**
+         * Declares a [KeyBindingVerifier] that just makes sure that the Key Binding JWT is present, and it's indeed a JWT
+         * without performing signature validation
+         *
+         * <em>Should not be used in production</em>
+         */
+        val MustBePresent: MustBePresentAndValid by lazy {
+            MustBePresentAndValid { JwtSignatureVerifier.NoSignatureValidation }
+        }
 
         internal fun KeyBindingError.asException(): SdJwtVerificationException =
             KeyBindingFailed(this).asException()

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.sdjwt
 
 import eu.europa.ec.eudi.sdjwt.KeyBindingError.*
+import eu.europa.ec.eudi.sdjwt.KeyBindingVerifier.Companion.MustBePresent
 import eu.europa.ec.eudi.sdjwt.KeyBindingVerifier.Companion.asException
 import eu.europa.ec.eudi.sdjwt.SdJwtVerifier.verifyIssuance
 import eu.europa.ec.eudi.sdjwt.SdJwtVerifier.verifyPresentation
@@ -127,7 +128,16 @@ fun interface JwtSignatureVerifier {
         this.checkSignature(jwt)?.let { claims -> if (additionalCondition(claims)) claims else null }
     }
 
-    companion object
+    companion object {
+
+        /**
+         * A [JwtSignatureVerifier] is added to the companion object, which just checks/parses the JWT,
+         * without performing signature validation.
+         *
+         * <em>Should not be used in production use cases</em>
+         */
+        val NoSignatureValidation: JwtSignatureVerifier = PlatformJwtSignatureVerifierNoSignatureValidation
+    }
 }
 
 /**
@@ -178,7 +188,11 @@ sealed interface KeyBindingVerifier {
      *
      * @return the claims of the Key Binding JWT, in case of [MustBePresentAndValid], otherwise null.
      */
-    suspend fun verify(jwtClaims: JsonObject, expectedDigest: SdJwtDigest, unverifiedKbJwt: String?): Result<JsonObject?> =
+    suspend fun verify(
+        jwtClaims: JsonObject,
+        expectedDigest: SdJwtDigest,
+        unverifiedKbJwt: String?,
+    ): Result<JsonObject?> =
         runCatching {
             fun mustBeNotPresent(): JsonObject? =
                 if (unverifiedKbJwt != null) throw UnexpectedKeyBindingJwt.asException()

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
@@ -104,7 +104,7 @@ fun interface JwtSignatureVerifier {
      * @param jwt the JWT to validate
      * @return the payload of the JWT if signature is valid, otherwise raises [InvalidJwt]
      */
-    suspend fun verify(jwt: String): Result<Claims> =
+    suspend fun verify(jwt: String): Result<JsonObject> =
         runCatching {
             checkSignature(jwt) ?: throw InvalidJwt.asException()
         }
@@ -114,7 +114,7 @@ fun interface JwtSignatureVerifier {
      * @param jwt the JWT to validate
      * @return the payload of the JWT if signature is valid, otherwise null
      */
-    suspend fun checkSignature(jwt: String): Claims?
+    suspend fun checkSignature(jwt: String): JsonObject?
 
     /**
      * Constructs a new [JwtSignatureVerifier] that in addition applies to the
@@ -123,7 +123,7 @@ fun interface JwtSignatureVerifier {
      * @return a new [JwtSignatureVerifier] that in addition applies to the
      *  extracted payload the [additionalCondition]
      */
-    fun and(additionalCondition: suspend (Claims) -> Boolean): JwtSignatureVerifier = JwtSignatureVerifier { jwt ->
+    fun and(additionalCondition: suspend (JsonObject) -> Boolean): JwtSignatureVerifier = JwtSignatureVerifier { jwt ->
         this.checkSignature(jwt)?.let { claims -> if (additionalCondition(claims)) claims else null }
     }
 
@@ -178,13 +178,13 @@ sealed interface KeyBindingVerifier {
      *
      * @return the claims of the Key Binding JWT, in case of [MustBePresentAndValid], otherwise null.
      */
-    suspend fun verify(jwtClaims: Claims, expectedDigest: SdJwtDigest, unverifiedKbJwt: String?): Result<Claims?> =
+    suspend fun verify(jwtClaims: JsonObject, expectedDigest: SdJwtDigest, unverifiedKbJwt: String?): Result<JsonObject?> =
         runCatching {
-            fun mustBeNotPresent(): Claims? =
+            fun mustBeNotPresent(): JsonObject? =
                 if (unverifiedKbJwt != null) throw UnexpectedKeyBindingJwt.asException()
                 else null
 
-            suspend fun mustBePresentAndValid(keyBindingVerifierProvider: (Claims) -> JwtSignatureVerifier?): Claims {
+            suspend fun mustBePresentAndValid(keyBindingVerifierProvider: (JsonObject) -> JwtSignatureVerifier?): JsonObject {
                 if (unverifiedKbJwt == null) throw MissingKeyBindingJwt.asException()
 
                 val keyBindingJwtVerifier =
@@ -220,7 +220,7 @@ sealed interface KeyBindingVerifier {
      * It assumes that Issuer has included somehow the holder pub key to SD-JWT.
      *
      */
-    class MustBePresentAndValid(val keyBindingVerifierProvider: (Claims) -> JwtSignatureVerifier?) :
+    class MustBePresentAndValid(val keyBindingVerifierProvider: (JsonObject) -> JwtSignatureVerifier?) :
         KeyBindingVerifier
 
     companion object {
@@ -231,9 +231,9 @@ sealed interface KeyBindingVerifier {
 }
 
 /**
- * Representation of a JWT both as [string][Jwt] and its [payload][Claims]
+ * Representation of a JWT both as [string][Jwt] and its payload claims
  */
-typealias JwtAndClaims = Pair<Jwt, Claims>
+typealias JwtAndClaims = Pair<Jwt, JsonObject>
 
 /**
  * A single point for verifying SD-JWTs in both [Combined Issuance Format][verifyIssuance]
@@ -387,7 +387,7 @@ object SdJwtVerifier {
 internal fun verifyIssuance(
     unverifiedJwt: Jwt,
     unverifiedDisclosures: List<String>,
-    jwtClaimsExtractor: (Jwt) -> Claims,
+    jwtClaimsExtractor: (Jwt) -> JsonObject,
 ): Result<SdJwt.Issuance<JwtAndClaims>> = runCatching {
     val jwtClaims = jwtClaimsExtractor(unverifiedJwt)
     val hashAlgorithm = hashingAlgorithmClaim(jwtClaims)
@@ -452,7 +452,7 @@ private fun uniqueDisclosures(unverifiedDisclosures: List<String>): List<Disclos
  * @return the hashing algorithm, if a hashing algorithm is present and contains a string
  * representing a supported [HashAlgorithm]. Otherwise raises [MissingOrUnknownHashingAlgorithm]
  */
-private fun hashingAlgorithmClaim(jwtClaims: Claims): HashAlgorithm {
+private fun hashingAlgorithmClaim(jwtClaims: JsonObject): HashAlgorithm {
     val element = jwtClaims[SdJwtSpec.CLAIM_SD_ALG] ?: JsonPrimitive("sha-256")
     val alg =
         if (element is JsonPrimitive) HashAlgorithm.fromString(element.content)
@@ -466,7 +466,7 @@ private fun hashingAlgorithmClaim(jwtClaims: Claims): HashAlgorithm {
  * @param disclosures the disclosures, of the SD-JWT
  * @return digests from both the JWT payload and the [disclosures][Disclosure], assuring that they are unique
  */
-private fun collectDigests(jwtClaims: Claims, disclosures: List<Disclosure>): Set<DisclosureDigest> {
+private fun collectDigests(jwtClaims: JsonObject, disclosures: List<Disclosure>): Set<DisclosureDigest> {
     // Get Digests
     val jwtDigests = collectDigests(jwtClaims)
     val disclosureDigests = disclosures.map { d -> collectDigests(JsonObject(mapOf(d.claim()))) }.flatten()
@@ -483,7 +483,7 @@ private fun collectDigests(jwtClaims: Claims, disclosures: List<Disclosure>): Se
  * @param claims to use
  * @return the digests found in the given [claims]
  */
-internal fun collectDigests(claims: Claims): List<DisclosureDigest> {
+internal fun collectDigests(claims: JsonObject): List<DisclosureDigest> {
     fun digestsOf(attribute: String, json: JsonElement): List<DisclosureDigest> =
         when {
             attribute == SdJwtSpec.CLAIM_SD && json is JsonArray -> json.mapNotNull { element ->
@@ -501,7 +501,7 @@ internal fun collectDigests(claims: Claims): List<DisclosureDigest> {
     return claims.map { (attribute, json) -> digestsOf(attribute, json) }.flatten()
 }
 
-internal fun JwsJsonSupport.parseIntoStandardForm(unverifiedSdJwt: Claims): String {
+internal fun JwsJsonSupport.parseIntoStandardForm(unverifiedSdJwt: JsonObject): String {
     val (unverifiedJwt, unverifiedDisclosures, unverifiedKBJwt) =
         parseJWSJson(unverifiedSdJwt)
     val jwtAndDisclosures = StandardSerialization.concat(unverifiedJwt, unverifiedDisclosures)

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Types.kt
@@ -95,7 +95,7 @@ sealed interface SdJwt<out JWT> {
      * @param jwt The JWT part of the SD-JWT
      * @param disclosures the full set of disclosures
      */
-    data class Issuance<JWT>(
+    data class Issuance<out JWT>(
         override val jwt: JWT,
         override val disclosures: List<Disclosure>,
     ) : SdJwt<JWT>
@@ -105,7 +105,7 @@ sealed interface SdJwt<out JWT> {
      * @param jwt the JWT part of the SD-JWT
      * @param disclosures the disclosures that holder decided to disclose to the verifier
      */
-    data class Presentation<JWT>(
+    data class Presentation<out JWT>(
         override val jwt: JWT,
         override val disclosures: List<Disclosure>,
     ) : SdJwt<JWT>

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Types.kt
@@ -110,5 +110,17 @@ sealed interface SdJwt<out JWT> {
         override val disclosures: List<Disclosure>,
     ) : SdJwt<JWT>
 
-    companion object
+    companion object : UnverifiedIssuanceFrom by PlatformSdJwtUnverifiedIssuanceFrom
+}
+
+fun interface UnverifiedIssuanceFrom {
+    /**
+     * A method for obtaining an [SdJwt.Issuance] given an [unverifiedSdJwt], without checking the signature
+     * of the issuer.
+     *
+     * The method can be useful in case where a holder has previously [verified][SdJwtVerifier.verifyIssuance] the SD-JWT and
+     * wants to just re-obtain an instance of the [SdJwt.Issuance] without repeating this verification
+     *
+     */
+    fun unverifiedIssuanceFrom(unverifiedSdJwt: String): Result<SdJwt.Issuance<JwtAndClaims>>
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Types.kt
@@ -42,12 +42,6 @@ fun Claim.name(): String = first
 fun Claim.value(): JsonElement = second
 
 /**
- * Representations of multiple claims
- *
- */
-typealias Claims = Map<String, JsonElement>
-
-/**
  * Salt to be included in a [Disclosure] claim.
  */
 typealias Salt = String

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.sdjwt.vc
 
 import eu.europa.ec.eudi.sdjwt.*
+import eu.europa.ec.eudi.sdjwt.jsonObject
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcIssuerPublicKeySource.*
 import io.ktor.client.*
 import io.ktor.http.*
@@ -216,7 +217,7 @@ fun sdJwtVcSignatureVerifier(
         val signedJwt = NimbusSignedJWT.parse(unverifiedJwt)
         val jwkSource = issuerJwkSource(httpClientFactory, trust, lookup, signedJwt)
         val jwtProcessor = SdJwtVcJwtProcessor(jwkSource)
-        jwtProcessor.process(signedJwt, null).asClaims()
+        jwtProcessor.process(signedJwt, null).jsonObject()
     } catch (_: NimbusBadJOSEException) {
         null
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DecoyTest.kt
@@ -82,7 +82,7 @@ internal class DecoyTest {
 
     // That's not safe, but it will do for them example
     // counts only top-level digests
-    private fun SdJwt.Issuance<SignedJWT>.countDigests() = jwt.jwtClaimsSet.asClaims().directDigests().count()
+    private fun SdJwt.Issuance<SignedJWT>.countDigests() = jwt.jwtClaimsSet.jsonObject().directDigests().count()
 
     private fun Membership.sdJwtSpec(minimumDigests: Int?) =
         sdJwt(minimumDigests) {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -80,7 +80,7 @@ class KeyBindingTest {
         }
         // Assert Disclosed claims
         val selectivelyDisclosedClaims =
-            issuedSdJwt.recreateClaims { it.jwtClaimsSet.asClaims() }["credentialSubject"]?.jsonObject
+            issuedSdJwt.recreateClaims { it.jwtClaimsSet.jsonObject() }["credentialSubject"]?.jsonObject
                 ?: JsonObject(emptyMap())
 
         assertEquals(5, selectivelyDisclosedClaims.size)

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -75,7 +75,7 @@ class PidDevVerificationTest : Printer {
 
 private interface Printer {
 
-    fun prettyPrint(issuedSdJwt: SdJwt.Issuance<Claims>) {
+    fun prettyPrint(issuedSdJwt: SdJwt.Issuance<JsonObject>) {
         // Output the debug info
         printHeader("Debug info")
         issuedSdJwt.prettyPrint { it }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PresentationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PresentationTest.kt
@@ -111,8 +111,8 @@ class PresentationTest {
     private val issuedSdJwt: SdJwt.Issuance<SignedJWT> by lazy {
         val sdJwt = issuer.issue(pidSpec).getOrThrow()
         println("Issued: ${sdJwt.serialize()}")
-        sdJwt.prettyPrint { it.jwtClaimsSet.asClaims() }
-        sdJwt.recreateClaimsAndDisclosuresPerClaim { it.jwtClaimsSet.asClaims() }.also { (json, map) ->
+        sdJwt.prettyPrint { it.jwtClaimsSet.jsonObject() }
+        sdJwt.recreateClaimsAndDisclosuresPerClaim { it.jwtClaimsSet.jsonObject() }.also { (json, map) ->
             println(json.pretty())
             map.prettyPrint()
         }
@@ -346,14 +346,14 @@ class PresentationTest {
 }
 
 private fun SdJwt<SignedJWT>.prettyPrintAll() {
-    val (claims, disclosuresPerClaim) = recreateClaimsAndDisclosuresPerClaim { it.jwtClaimsSet.asClaims() }
-    prettyPrint { it.jwtClaimsSet.asClaims() }
+    val (claims, disclosuresPerClaim) = recreateClaimsAndDisclosuresPerClaim { it.jwtClaimsSet.jsonObject() }
+    prettyPrint { it.jwtClaimsSet.jsonObject() }
     println(claims.pretty())
     disclosuresPerClaim.forEach { (p, ds) ->
         println("$p - ${if (ds.isEmpty()) "plain" else "$ds"}")
     }
 }
 
-private fun Claims.pretty(): String = jsonSupport.encodeToString(JsonObject(this))
+private fun JsonObject.pretty(): String = jsonSupport.encodeToString(JsonObject(this))
 private val jsonSupport: Json = Json { prettyPrint = true }
 private fun genKey(kid: String): ECKey = ECKeyGenerator(Curve.P_256).keyID(kid).generate()

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/RecreateClaimsTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/RecreateClaimsTest.kt
@@ -36,7 +36,7 @@ class RecreateClaimsTest {
         assertEquals(plainClaims, actual)
     }
 
-    private fun discloseAndRecreate(sdElements: SdObject): Claims {
+    private fun discloseAndRecreate(sdElements: SdObject): JsonObject {
         val sdJwt = SdJwtFactory().createSdJwt(sdElements).getOrThrow()
         return sdJwt.recreateClaims().also {
             println(json.encodeToString(it))

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Utils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Utils.kt
@@ -48,7 +48,7 @@ val json = Json {
 
 private fun JsonElement.pretty(): String = json.encodeToString(this)
 
-fun <JWT> SdJwt<JWT>.prettyPrint(f: (JWT) -> Claims) {
+fun <JWT> SdJwt<JWT>.prettyPrint(f: (JWT) -> JsonObject) {
     val type = when (this) {
         is SdJwt.Issuance -> "issuance"
         is SdJwt.Presentation -> "presentation"

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleRecreateClaims01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleRecreateClaims01.kt
@@ -19,10 +19,11 @@ import com.nimbusds.jose.*
 import com.nimbusds.jose.crypto.*
 import com.nimbusds.jose.jwk.*
 import eu.europa.ec.eudi.sdjwt.*
+import eu.europa.ec.eudi.sdjwt.jsonObject
 import kotlinx.serialization.json.*
 import com.nimbusds.jwt.SignedJWT as NimbusSignedJWT
 
-val claims: Claims = run {
+val claims: JsonObject = run {
     val issuerKeyPair: RSAKey = loadRsaKey("/examplesIssuerKey.json")
     val sdJwt: SdJwt.Issuance<NimbusSignedJWT> =
         signedSdJwt(signer = RSASSASigner(issuerKeyPair), signAlgorithm = JWSAlgorithm.RS256) {
@@ -41,5 +42,5 @@ val claims: Claims = run {
                 }
             }
         }
-    sdJwt.recreateClaims { jwt -> jwt.jwtClaimsSet.asClaims() }
+    sdJwt.recreateClaims { jwt -> jwt.jwtClaimsSet.jsonObject() }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
@@ -23,6 +23,7 @@ import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.sdjwt.*
+import eu.europa.ec.eudi.sdjwt.jsonObject
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
@@ -260,7 +261,7 @@ class SdJwtVcIssuanceTest {
     }
 
     private fun SdJwt.Issuance<SignedJWT>.print() {
-        prettyPrint { it.jwtClaimsSet.asClaims() }
+        prettyPrint { it.jwtClaimsSet.jsonObject() }
     }
 
     private fun SdJwt.Issuance<SignedJWT>.printInJwsJson(option: JwsSerializationOption) {


### PR DESCRIPTION
This PR:

- Deprecates the typealias Claims (`Map<String,JsonElement>`)  in favor of `JsonObject` from kotlinx.serialization
- Makes some companion object extends more KMP friendly (used to be in NimbusIntegration.kt)
- Fixes as contravariant the `JWT` parameter of the `SdJwt<out JWT>` GADT
- Redefines the `SdJwtIssuer` as an interface 

The 1st may cause some minor breaking problems, since `Claims` was part of the public API. 
The rest of the changes doesn't introduce any changes to the caller side. The public API remains the same.

Closes #271 
