### PR TITLE
SdJwtRecreateClaimsOps

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOps.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOps.kt
@@ -23,7 +23,8 @@ import kotlinx.serialization.json.jsonPrimitive
 interface DefaultSdJwtOps :
     SdJwtVerifier,
     SdJwtSerializationOps<JwtAndClaims>,
-    SdJwtPresentationOps<JwtAndClaims> {
+    SdJwtPresentationOps<JwtAndClaims>,
+    SdJwtRecreateClaimsOps<JwtAndClaims> {
 
     override fun SdJwt<JwtAndClaims>.serialize(): String =
         with(serializationOps) { serialize() }
@@ -52,6 +53,9 @@ interface DefaultSdJwtOps :
         option: JwsSerializationOption,
         buildKbJwt: BuildKbJwt,
     ): Result<JsonObject> = with(serializationOps) { asJwsJsonObjectWithKeyBinding(option, buildKbJwt) }
+
+    override fun SdJwt<JwtAndClaims>.recreateClaims(visitor: ClaimVisitor?): JsonObject =
+        with(presentationOps) { recreateClaims(visitor) }
 
     companion object : DefaultSdJwtOps
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Deprecated.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Deprecated.kt
@@ -272,7 +272,6 @@ fun SdJwt.Issuance<NimbusSignedJWT>.present(query: Set<ClaimPath>): SdJwt.Presen
  * @param claimsOf a function to obtain the claims of the [SdJwt.jwt]
  * @param JWT the type representing the JWT part of the SD-JWT
  *
- * @see SdJwt.recreateClaims
  */
 @Deprecated(
     message = "This method will be removed in a future version",
@@ -298,3 +297,42 @@ fun <JWT> SdJwt.Issuance<JWT>.present(
     query: Set<ClaimPath>,
     claimsOf: (JWT) -> JsonObject,
 ): SdJwt.Presentation<JWT>? = with(SdJwtPresentationOps(claimsOf)) { present(query) }
+
+/**
+ * Recreates the claims, used to produce the SD-JWT
+ * That are:
+ * - The plain claims found into the [SdJwt.jwt]
+ * - Digests found in [SdJwt.jwt] and/or [Disclosure] (in case of recursive disclosure) will
+ *   be replaced by [Disclosure.claim]
+ *
+ * @param claimsOf a function to get the claims of the [SdJwt.jwt]
+ * @param JWT the type representing the JWT part of the SD-JWT
+ * @receiver the SD-JWT to use
+ * @return the claims that were used to produce the SD-JWT
+ */
+@Deprecated(
+    message = "Replace with SdJwtSerializationOps",
+    replaceWith = ReplaceWith("with(SdJwtRecreateClaimsOps(claimsOf)) { recreateClaims(visitor = null) }"),
+)
+fun <JWT> SdJwt<JWT>.recreateClaims(claimsOf: (JWT) -> JsonObject): JsonObject =
+    with(SdJwtRecreateClaimsOps(claimsOf)) { recreateClaims(visitor = null) }
+
+/**
+ * Recreates the claims, used to produce the SD-JWT
+ * That are:
+ * - The plain claims found into the [SdJwt.jwt]
+ * - Digests found in [SdJwt.jwt] and/or [Disclosure] (in case of recursive disclosure) will
+ *   be replaced by [Disclosure.claim]
+ *
+ * @param visitor [ClaimVisitor] to invoke whenever a selectively disclosed claim is encountered
+ * @param claimsOf a function to get the claims of the [SdJwt.jwt]
+ * @param JWT the type representing the JWT part of the SD-JWT
+ * @receiver the SD-JWT to use
+ * @return the claims that were used to produce the SD-JWT
+ */
+@Deprecated(
+    message = "Replace with SdJwtSerializationOps",
+    replaceWith = ReplaceWith(" with(SdJwtRecreateClaimsOps(claimsOf)) { recreateClaims(visitor) }"),
+)
+fun <JWT> SdJwt<JWT>.recreateClaims(visitor: ClaimVisitor? = null, claimsOf: (JWT) -> JsonObject): JsonObject =
+    with(SdJwtRecreateClaimsOps(claimsOf)) { recreateClaims(visitor) }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -284,6 +284,9 @@ interface NimbusSdJwtOps : SdJwtSerializationOps<NimbusSignedJWT>, SdJwtPresenta
         buildKbJwt: BuildKbJwt,
     ): Result<JsonObject> = with(defaultOps) { asJwsJsonObjectWithKeyBinding(option, buildKbJwt) }
 
+    override fun SdJwt<NimbusSignedJWT>.recreateClaims(visitor: ClaimVisitor?): JsonObject =
+        with(presentationOps) { recreateClaims(visitor) }
+
     companion object : NimbusSdJwtOps {
 
         private val defaultOps: SdJwtSerializationOps<NimbusSignedJWT> =

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtPresent.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtPresent.kt
@@ -26,7 +26,7 @@ import kotlinx.serialization.json.JsonObject
  */
 typealias DisclosuresPerClaimPath = Map<ClaimPath, List<Disclosure>>
 
-interface SdJwtPresentationOps<JWT> {
+interface SdJwtPresentationOps<JWT> : SdJwtRecreateClaimsOps<JWT> {
     /**
      * Recreates the claims, used to produce the SD-JWT and at the same time calculates [DisclosuresPerClaim]
      *
@@ -34,7 +34,24 @@ interface SdJwtPresentationOps<JWT> {
      *
      * @see SdJwt.recreateClaims
      */
-    fun SdJwt<JWT>.recreateClaimsAndDisclosuresPerClaim(): Pair<JsonObject, DisclosuresPerClaimPath>
+    fun SdJwt<JWT>.recreateClaimsAndDisclosuresPerClaim(): Pair<JsonObject, DisclosuresPerClaimPath> {
+        val disclosuresPerClaim = mutableMapOf<ClaimPath, List<Disclosure>>()
+        val visitor = ClaimVisitor { path, disclosure ->
+            if (disclosure != null) {
+                require(path !in disclosuresPerClaim.keys) { "Disclosures for $path have already been calculated." }
+            }
+            val claimDisclosures = run {
+                val containerPath = path.parent()
+                val containerDisclosures = containerPath?.let { disclosuresPerClaim[it] }.orEmpty()
+                disclosure
+                    ?.let { containerDisclosures + it }
+                    ?: containerDisclosures
+            }
+            disclosuresPerClaim.putIfAbsent(path, claimDisclosures)
+        }
+        val claims = recreateClaims(visitor)
+        return claims to disclosuresPerClaim
+    }
 
     /**
      * Tries to create a presentation that discloses the [requested claims][query].
@@ -44,45 +61,24 @@ interface SdJwtPresentationOps<JWT> {
      * @param JWT the type representing the JWT part of the SD-JWT
      * @return the presentation if possible to satisfy the [query]
      */
-    fun SdJwt.Issuance<JWT>.present(query: Set<ClaimPath>): SdJwt.Presentation<JWT>?
+    fun SdJwt.Issuance<JWT>.present(query: Set<ClaimPath>): SdJwt.Presentation<JWT>? {
+        val (_, disclosuresPerClaim) = recreateClaimsAndDisclosuresPerClaim()
+        infix fun ClaimPath.matches(other: ClaimPath): Boolean =
+            (value.size == other.value.size) && (this in other)
+
+        val keys = disclosuresPerClaim.keys.filter { claimFound ->
+            query.any { requested -> claimFound matches requested }
+        }
+        return if (keys.isEmpty()) null
+        else {
+            val ds = disclosuresPerClaim.filterKeys { it in keys }.values.flatten().toSet()
+            SdJwt.Presentation(jwt, ds.toList())
+        }
+    }
 
     companion object {
         operator fun <JWT> invoke(claimsOf: (JWT) -> JsonObject): SdJwtPresentationOps<JWT> =
-            object : SdJwtPresentationOps<JWT> {
-                override fun SdJwt<JWT>.recreateClaimsAndDisclosuresPerClaim(): Pair<JsonObject, DisclosuresPerClaimPath> {
-                    val disclosuresPerClaim = mutableMapOf<ClaimPath, List<Disclosure>>()
-                    val visitor = ClaimVisitor { path, disclosure ->
-                        if (disclosure != null) {
-                            require(path !in disclosuresPerClaim.keys) { "Disclosures for $path have already been calculated." }
-                        }
-                        val claimDisclosures = run {
-                            val containerPath = path.parent()
-                            val containerDisclosures = containerPath?.let { disclosuresPerClaim[it] }.orEmpty()
-                            disclosure
-                                ?.let { containerDisclosures + it }
-                                ?: containerDisclosures
-                        }
-                        disclosuresPerClaim.putIfAbsent(path, claimDisclosures)
-                    }
-                    val claims = recreateClaims(visitor, claimsOf)
-                    return claims to disclosuresPerClaim
-                }
-
-                override fun SdJwt.Issuance<JWT>.present(query: Set<ClaimPath>): SdJwt.Presentation<JWT>? {
-                    val (_, disclosuresPerClaim) = recreateClaimsAndDisclosuresPerClaim()
-                    infix fun ClaimPath.matches(other: ClaimPath): Boolean =
-                        (value.size == other.value.size) && (this in other)
-
-                    val keys = disclosuresPerClaim.keys.filter { claimFound ->
-                        query.any { requested -> claimFound matches requested }
-                    }
-                    return if (keys.isEmpty()) null
-                    else {
-                        val ds = disclosuresPerClaim.filterKeys { it in keys }.values.flatten().toSet()
-                        SdJwt.Presentation(jwt, ds.toList())
-                    }
-                }
-            }
+            object : SdJwtPresentationOps<JWT>, SdJwtRecreateClaimsOps<JWT> by SdJwtRecreateClaimsOps(claimsOf) {}
     }
 }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/RecreateClaimsTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/RecreateClaimsTest.kt
@@ -38,7 +38,7 @@ class RecreateClaimsTest {
 
     private fun discloseAndRecreate(sdElements: SdObject): JsonObject {
         val sdJwt = SdJwtFactory().createSdJwt(sdElements).getOrThrow()
-        return sdJwt.recreateClaims().also {
+        return sdJwt.recreateClaims({ it }).also {
             println(json.encodeToString(it))
         }
     }


### PR DESCRIPTION
This PR introduces a new interface named `SdJwtRecreateClaimsOps` as follows: 

```kotlin
fun interface SdJwtRecreateClaimsOps<in JWT> {
    fun SdJwt<JWT>.recreateClaims(visitor: ClaimVisitor?): JsonObject
}
```

Intention for this is to deprecate related top-level methods.
In addition, the `SdJwtPresentationOps` know extends the new interface.

