### PR TITLE
Define the methods of SdJwtVerifier and SdJwtVcVerifier more appropriately.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,6 @@ val issuedSdJwt: String = runBlocking {
 
 ## Holder Verification
 
-In this case, the SD-JWT is expected to be in serialized form.
-
 `Holder` must know:
 
 - the public key of the `Issuer` and the algorithm used by the Issuer to sign the SD-JWT
@@ -124,7 +122,7 @@ val verifiedIssuanceSdJwt: SdJwt<SignedJWT> = runBlocking {
         val issuerKeyPair = loadRsaKey("/examplesIssuerKey.json")
         val jwtSignatureVerifier = RSASSAVerifier(issuerKeyPair).asJwtVerifier()
         val unverifiedIssuanceSdJwt = loadSdJwt("/exampleIssuanceSdJwt.txt")
-        verifyIssuance(jwtSignatureVerifier, unverifiedIssuanceSdJwt).getOrThrow()
+        verify(jwtSignatureVerifier, unverifiedIssuanceSdJwt).getOrThrow()
     }
 }
 ```
@@ -193,9 +191,8 @@ disclosed as well.
 
 ## Presentation Verification
 
-### In simple format
+### Using compact serialization
 
-In this case, the SD-JWT is expected to be in Combined Presentation format.
 Verifier should know the public key of the Issuer and the algorithm used by the Issuer
 to sign the SD-JWT. Also, if verification includes Key Binding, the Verifier must also
 know how the public key of the Holder was included in the SD-JWT and which algorithm
@@ -214,9 +211,8 @@ val verifiedPresentationSdJwt: SdJwt<SignedJWT> = runBlocking {
         val issuerKeyPair = loadRsaKey("/examplesIssuerKey.json")
         val jwtSignatureVerifier = RSASSAVerifier(issuerKeyPair).asJwtVerifier()
         val unverifiedPresentationSdJwt = loadSdJwt("/examplePresentationSdJwt.txt")
-        val (sdJwt, _) = verifyPresentation(
+        val sdJwt = verify(
             jwtSignatureVerifier,
-            KeyBindingVerifier.MustNotBePresent,
             unverifiedPresentationSdJwt,
         ).getOrThrow()
         sdJwt
@@ -389,7 +385,7 @@ The library support verifying
 More specifically, Issuer-signed JWT Verification Key Validation support is provided by
 [SdJwtVcVerifier](src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt).  
 Please check [KeyBindingTest](src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt) for code examples of
-verifying an Issuance SD-JWT VC and a Presentation SD-JWT VC (including verification of the Key Binding JWT).
+verifying an SD-JWT VC and an SD-JWT+KB VC (including verification of the Key Binding JWT).
 
 Example:
 
@@ -461,7 +457,7 @@ val sdJwtVcVerification = runBlocking {
     }
 
     val verifier = NimbusSdJwtOps.usingX5c { chain -> chain.firstOrNull() == certificate }
-    verifier.verifyIssuance(sdJwt)
+    verifier.verify(sdJwt)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -211,11 +211,10 @@ val verifiedPresentationSdJwt: SdJwt<SignedJWT> = runBlocking {
         val issuerKeyPair = loadRsaKey("/examplesIssuerKey.json")
         val jwtSignatureVerifier = RSASSAVerifier(issuerKeyPair).asJwtVerifier()
         val unverifiedPresentationSdJwt = loadSdJwt("/examplePresentationSdJwt.txt")
-        val sdJwt = verify(
+        verify(
             jwtSignatureVerifier,
             unverifiedPresentationSdJwt,
         ).getOrThrow()
-        sdJwt
     }
 }
 ```

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOps.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOps.kt
@@ -45,15 +45,15 @@ private val DefaultSerializationOps = SdJwtSerializationOps<JwtAndClaims>(
     },
 )
 
-private val DefaultPresentationOps = SdJwtPresentationOps<JwtAndClaims>({ (_, claims) -> claims })
+private val DefaultPresentationOps = SdJwtPresentationOps<JwtAndClaims> { (_, claims) -> claims }
 
-private val DefaultVerifier: SdJwtVerifier<JwtAndClaims> = SdJwtVerifier({ (_, claims) -> claims })
+private val DefaultVerifier: SdJwtVerifier<JwtAndClaims> = SdJwtVerifier { (_, claims) -> claims }
 
 /**
  * A method for obtaining an [SdJwt] given an unverified SdJwt, without checking the signature
  * of the issuer.
  *
- * The method can be useful in case where a holder has previously [verified][SdJwtVerifier.verifyIssuance] the SD-JWT and
+ * The method can be useful in case where a holder has previously [verified][SdJwtVerifier.verify] the SD-JWT and
  * wants to just re-obtain an instance of the [SdJwt] without repeating this verification
  *
  */

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -307,7 +307,7 @@ private val NimbusSerializationOps: SdJwtSerializationOps<NimbusSignedJWT> =
 private val NimbusPresentationOps: SdJwtPresentationOps<NimbusSignedJWT> =
     SdJwtPresentationOps({ jwt -> jwt.jwtClaimsSet.jsonObject() })
 
-private val NimbusVerifier: SdJwtVerifier<NimbusSignedJWT> = SdJwtVerifier({ jwt -> jwt.jwtClaimsSet.jsonObject() })
+private val NimbusVerifier: SdJwtVerifier<NimbusSignedJWT> = SdJwtVerifier { jwt -> jwt.jwtClaimsSet.jsonObject() }
 
 /**
  * Creates a function that given some claims signs them producing a [NimbusSignedJWT]

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
@@ -260,7 +260,7 @@ fun interface UnverifiedIssuanceFrom<out JWT> {
      * A method for obtaining an [SdJwt] given an [unverifiedSdJwt], without checking the signature
      * of the issuer.
      *
-     * The method can be useful in case where a holder has previously [verified][SdJwtVerifier.verifyIssuance] the SD-JWT and
+     * The method can be useful in case where a holder has previously [verified][SdJwtVerifier.verify] the SD-JWT and
      * wants to just re-obtain an instance of the [SdJwt] without repeating this verification
      *
      */
@@ -273,13 +273,13 @@ fun interface UnverifiedIssuanceFrom<out JWT> {
 typealias JwtAndClaims = Pair<Jwt, JsonObject>
 
 /**
- * A single point for verifying SD-JWTs in both [Combined Issuance Format][verifyIssuance]
- * and [Combined Presentation Format][verifyPresentation]
+ * A single point for verifying SD-JWTs in both SD-JWT and SD-JWT+KB formats, using either compact or
+ * JWS JSON serialization.
  */
 interface SdJwtVerifier<JWT> {
 
     /**
-     * Verifies an SD-JWT (in simple format)
+     * Verifies an SD-JWT serialized using compact serialization.
      * Typically, this is useful to Holder that wants to verify an issued SD-JWT
      *
      * @param jwtSignatureVerifier the verification the SD-JWT signature.
@@ -290,14 +290,14 @@ interface SdJwtVerifier<JWT> {
      * @return the verified SD-JWT, if valid. Otherwise, method could raise a [SdJwtVerificationException]
      * The verified SD-JWT will contain a [JWT][SdJwt.jwt] as both string and decoded payload
      */
-    suspend fun verifyIssuance(
+    suspend fun verify(
         jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
         unverifiedSdJwt: String,
     ): Result<SdJwt<JWT>>
 
     /**
-     * Verifies an SD-JWT in JWS JSON general of flattened format as defined by RFC7515 and extended by SD-JWT
-     * specification
+     * Verifies an SD-JWT serialized using JWS JSON serialization (either general or flattened format) as defined by RFC7515
+     * and extended by SD-JWT specification.
      *
      * Typically, this is useful to Holder that wants to verify an issued SD-JWT
      *
@@ -312,57 +312,58 @@ interface SdJwtVerifier<JWT> {
      * Otherwise, method could raise a [SdJwtVerificationException]
      * The verified SD-JWT will contain a [JWT][SdJwt.jwt] as both string and decoded payload
      */
-    suspend fun verifyIssuance(
+    suspend fun verify(
         jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
         unverifiedSdJwt: JsonObject,
     ): Result<SdJwt<JWT>>
 
     /**
-     * Verifies a SD-JWT in Combined Presentation Format
-     * Typically, this is useful to Verifier that wants to verify presentation SD-JWT communicated by Holder
+     * Verifies a SD-JWT+KB serialized using compact serialization.
+     * Typically, this is useful to Verifier that want to verify presentation SD-JWT communicated by Holders.
      *
      * @param jwtSignatureVerifier the verification of SD-JWT signature.
      * To provide an implementation of this,
      * Verifier should be aware of the public key and the signing algorithm that the Issuer
      * used to sign the SD-JWT.
-     * @param keyBindingVerifier specifies whether a Key Binding JWT is expected or not.
-     * In the case that it is expected, Verifier should be aware of how the Issuer has chosen to include the
+     * @param keyBindingVerifier the verification of the KeyBinding signature
+     * Verifier should be aware of how the Issuer has chosen to include the
      * Holder public key into the SD-JWT and which algorithm the Holder used to sign the challenge of the Verifier.
      * @param unverifiedSdJwt the SD-JWT to be verified
-     * @return the verified SD-JWT and the key binding JWT, if valid.
+     * @return the verified SD-JWT and the KeyBinding JWT, if valid.
      * Otherwise, method could raise a [SdJwtVerificationException]
-     * The verified SD-JWT will the [JWT][SdJwt.jwt] and key binding JWT
+     * The verified SD-JWT will the [JWT][SdJwt.jwt] and KeyBinding JWT
      * are representing in both string and decoded payload.
      * Expected errors are reported via a [SdJwtVerificationException]
      */
-    suspend fun verifyPresentation(
+    suspend fun verify(
         jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
-        keyBindingVerifier: KeyBindingVerifier<JWT>,
+        keyBindingVerifier: KeyBindingVerifier.MustBePresentAndValid<JWT>,
         unverifiedSdJwt: String,
-    ): Result<Pair<SdJwt<JWT>, JWT?>>
+    ): Result<Pair<SdJwt<JWT>, JWT>>
 
     /**
-     * Verifies a SD-JWT in JWS JSON serialization
-     * Typically, this is useful to Verifier that wants to verify presentation SD-JWT communicated by Holder
+     * Verifies a SD-JWT+KB in JWS JSON serialization.
+     * Typically, this is useful to Verifier that want to verify presentation SD-JWT communicated by Holders
      *
      * @param jwtSignatureVerifier the verification of SD-JWT signature.
      * To provide an implementation of this,
      * Verifier should be aware of the public key and the signing algorithm that the Issuer
      * used to sign the SD-JWT.
-     * @param keyBindingVerifier specifies whether a Key Binding JWT is expected or not.
-     * In the case that it is expected, Verifier should be aware of how the Issuer has chosen to include the
+     * @param keyBindingVerifier the verification of the KeyBinding signature
+     * Verifier should be aware of how the Issuer has chosen to include the
      * Holder public key into the SD-JWT and which algorithm the Holder used to sign the challenge of the Verifier.
      * @param unverifiedSdJwt the SD-JWT to be verified
-     * @return the verified SD-JWT, if valid. Otherwise, method could raise a [SdJwtVerificationException]
-     * The verified SD-JWT will the [JWT][SdJwt.jwt] and key binding JWT
+     * @return the verified SD-JWT and KeyBinding JWT, if valid.
+     * Otherwise, method could raise a [SdJwtVerificationException]
+     * The verified SD-JWT will the [JWT][SdJwt.jwt] and KeyBinding JWT
      * are representing in both string and decoded payload.
      * Expected errors are reported via a [SdJwtVerificationException]
      */
-    suspend fun verifyPresentation(
+    suspend fun verify(
         jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
-        keyBindingVerifier: KeyBindingVerifier<JWT>,
+        keyBindingVerifier: KeyBindingVerifier.MustBePresentAndValid<JWT>,
         unverifiedSdJwt: JsonObject,
-    ): Result<Pair<SdJwt<JWT>, JWT?>>
+    ): Result<Pair<SdJwt<JWT>, JWT>>
 
     companion object {
 
@@ -370,46 +371,53 @@ interface SdJwtVerifier<JWT> {
             claimsOf: (JWT) -> JsonObject,
         ): SdJwtVerifier<JWT> = object : SdJwtVerifier<JWT> {
 
-            override suspend fun verifyIssuance(
+            override suspend fun verify(
                 jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
                 unverifiedSdJwt: String,
             ): Result<SdJwt<JWT>> = runCatching {
-                // Parse
-                val (unverifiedJwt, unverifiedDisclosures) = StandardSerialization.parseIssuance(unverifiedSdJwt)
-                verifyIssuance(jwtSignatureVerifier, unverifiedJwt, unverifiedDisclosures).getOrThrow()
+                val (sdJwt, kbJwt) = doVerify(
+                    jwtSignatureVerifier,
+                    KeyBindingVerifier.MustNotBePresent,
+                    unverifiedSdJwt,
+                ).getOrThrow()
+
+                check(kbJwt == null) { "unexpected KeyBinding JWT" }
+                sdJwt
             }
 
-            override suspend fun verifyIssuance(
+            override suspend fun verify(
                 jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
                 unverifiedSdJwt: JsonObject,
-            ): Result<SdJwt<JWT>> = runCatching {
-                val (unverifiedJwt, unverifiedDisclosures, unverifiedKbJwt) = JwsJsonSupport.parseJWSJson(
-                    unverifiedSdJwt,
-                )
-                if (null != unverifiedKbJwt) throw UnexpectedKeyBindingJwt.asException()
-                verifyIssuance(jwtSignatureVerifier, unverifiedJwt, unverifiedDisclosures).getOrThrow()
-            }
+            ): Result<SdJwt<JWT>> = verify(jwtSignatureVerifier, JwsJsonSupport.parseIntoStandardForm(unverifiedSdJwt))
 
-            private suspend fun verifyIssuance(
+            override suspend fun verify(
                 jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
-                unverifiedJwt: Jwt,
-                unverifiedDisclosures: List<String>,
-            ): Result<SdJwt<JWT>> = runCatching {
-                // Check JWT signature
-                val jwt = jwtSignatureVerifier.verify(unverifiedJwt).getOrThrow()
-                val claims = claimsOf(jwt)
-                val disclosures = verifyDisclosures(claims, unverifiedDisclosures).getOrThrow()
-                SdJwt(jwt, disclosures)
+                keyBindingVerifier: KeyBindingVerifier.MustBePresentAndValid<JWT>,
+                unverifiedSdJwt: String,
+            ): Result<Pair<SdJwt<JWT>, JWT>> = runCatching {
+                val (sdJwt, kbJwt) = doVerify(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt).getOrThrow()
+                checkNotNull(kbJwt) { "KeyBinding JWT is expected" }
+                sdJwt to kbJwt
             }
 
-            override suspend fun verifyPresentation(
+            override suspend fun verify(
+                jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
+                keyBindingVerifier: KeyBindingVerifier.MustBePresentAndValid<JWT>,
+                unverifiedSdJwt: JsonObject,
+            ): Result<Pair<SdJwt<JWT>, JWT>> = verify(
+                jwtSignatureVerifier,
+                keyBindingVerifier,
+                JwsJsonSupport.parseIntoStandardForm(unverifiedSdJwt),
+            )
+
+            private suspend fun doVerify(
                 jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
                 keyBindingVerifier: KeyBindingVerifier<JWT>,
                 unverifiedSdJwt: String,
             ): Result<Pair<SdJwt<JWT>, JWT?>> = runCatching {
                 // Parse
-                val (unverifiedJwt, unverifiedDisclosures, unverifiedKBJwt) =
-                    StandardSerialization.parse(unverifiedSdJwt)
+                val (unverifiedJwt, unverifiedDisclosures, unverifiedKBJwt) = StandardSerialization.parse(unverifiedSdJwt)
+
                 // Check JWT
                 val jwt = jwtSignatureVerifier.verify(unverifiedJwt).getOrThrow()
                 val jwtClaims = claimsOf(jwt)
@@ -428,16 +436,6 @@ interface SdJwtVerifier<JWT> {
                 // Assemble it
                 val sdJwt = SdJwt(jwt, disclosures)
                 sdJwt to kbJwt
-            }
-
-            override suspend fun verifyPresentation(
-                jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
-                keyBindingVerifier: KeyBindingVerifier<JWT>,
-                unverifiedSdJwt: JsonObject,
-            ): Result<Pair<SdJwt<JWT>, JWT?>> = runCatching {
-                // Parse and re-assemble it in combined form
-                val unverifiedSdJwtAsString = JwsJsonSupport.parseIntoStandardForm(unverifiedSdJwt)
-                verifyPresentation(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwtAsString).getOrThrow()
             }
         }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
@@ -280,7 +280,9 @@ interface SdJwtVerifier<JWT> {
 
     /**
      * Verifies an SD-JWT serialized using compact serialization.
-     * Typically, this is useful to Holder that wants to verify an issued SD-JWT
+     *
+     * Typically, this is useful to Holder that wants to verify an issued SD-JWT, or to Verifier that wants to verify
+     * a presented SD-JWT in case the KB-JWT [must not be present][KeyBindingVerifier.MustNotBePresent].
      *
      * @param jwtSignatureVerifier the verification the SD-JWT signature.
      * To provide an implementation of this,
@@ -299,7 +301,8 @@ interface SdJwtVerifier<JWT> {
      * Verifies an SD-JWT serialized using JWS JSON serialization (either general or flattened format) as defined by RFC7515
      * and extended by SD-JWT specification.
      *
-     * Typically, this is useful to Holder that wants to verify an issued SD-JWT
+     * Typically, this is useful to Holder that wants to verify an issued SD-JWT, or to Verifier that wants to verify
+     * a presented SD-JWT in case the KB-JWT [must not be present][KeyBindingVerifier.MustNotBePresent].
      *
      * @param jwtSignatureVerifier the verification the SD-JWT signature.
      * To provide an implementation of this,
@@ -319,7 +322,8 @@ interface SdJwtVerifier<JWT> {
 
     /**
      * Verifies a SD-JWT+KB serialized using compact serialization.
-     * Typically, this is useful to Verifier that want to verify presentation SD-JWT communicated by Holders.
+     *
+     * Typically, this is useful to Verifiers that want to verify presentation SD-JWT communicated by Holders.
      *
      * @param jwtSignatureVerifier the verification of SD-JWT signature.
      * To provide an implementation of this,
@@ -339,11 +343,12 @@ interface SdJwtVerifier<JWT> {
         jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
         keyBindingVerifier: KeyBindingVerifier.MustBePresentAndValid<JWT>,
         unverifiedSdJwt: String,
-    ): Result<Pair<SdJwt<JWT>, JWT>>
+    ): Result<SdJwtAndKbJwt<JWT>>
 
     /**
      * Verifies a SD-JWT+KB in JWS JSON serialization.
-     * Typically, this is useful to Verifier that want to verify presentation SD-JWT communicated by Holders
+     *
+     * Typically, this is useful to Verifiers that want to verify presentation SD-JWT communicated by Holders
      *
      * @param jwtSignatureVerifier the verification of SD-JWT signature.
      * To provide an implementation of this,
@@ -363,7 +368,7 @@ interface SdJwtVerifier<JWT> {
         jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
         keyBindingVerifier: KeyBindingVerifier.MustBePresentAndValid<JWT>,
         unverifiedSdJwt: JsonObject,
-    ): Result<Pair<SdJwt<JWT>, JWT>>
+    ): Result<SdJwtAndKbJwt<JWT>>
 
     companion object {
 
@@ -394,17 +399,17 @@ interface SdJwtVerifier<JWT> {
                 jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
                 keyBindingVerifier: KeyBindingVerifier.MustBePresentAndValid<JWT>,
                 unverifiedSdJwt: String,
-            ): Result<Pair<SdJwt<JWT>, JWT>> = runCatching {
+            ): Result<SdJwtAndKbJwt<JWT>> = runCatching {
                 val (sdJwt, kbJwt) = doVerify(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt).getOrThrow()
                 checkNotNull(kbJwt) { "KeyBinding JWT is expected" }
-                sdJwt to kbJwt
+                SdJwtAndKbJwt(sdJwt, kbJwt)
             }
 
             override suspend fun verify(
                 jwtSignatureVerifier: JwtSignatureVerifier<JWT>,
                 keyBindingVerifier: KeyBindingVerifier.MustBePresentAndValid<JWT>,
                 unverifiedSdJwt: JsonObject,
-            ): Result<Pair<SdJwt<JWT>, JWT>> = verify(
+            ): Result<SdJwtAndKbJwt<JWT>> = verify(
                 jwtSignatureVerifier,
                 keyBindingVerifier,
                 JwsJsonSupport.parseIntoStandardForm(unverifiedSdJwt),

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Types.kt
@@ -97,3 +97,20 @@ inline fun <JWT, JWT1> SdJwt<JWT>.map(f: (JWT) -> JWT1): SdJwt<JWT1> {
     }
     return SdJwt<JWT1>(f(jwt), disclosures)
 }
+
+/**
+ * A parameterized representation of a presented SD-JWT
+ * with a [keyBindingJwt]
+ *
+ * @param sdJwt the SD-JWT
+ * @param keyBindingJwt a KB-JWT, associated with the [sdJwt]
+ * @param JWT  the type representing the JWT
+ */
+data class SdJwtAndKbJwt<out JWT>(val sdJwt: SdJwt<JWT>, val keyBindingJwt: JWT)
+
+inline fun <JWT, JWT1> SdJwtAndKbJwt<JWT>.map(f: (JWT) -> JWT1): SdJwtAndKbJwt<JWT1> {
+    contract {
+        callsInPlace(f, InvocationKind.UNKNOWN)
+    }
+    return SdJwtAndKbJwt<JWT1>(sdJwt.map(f), keyBindingJwt.let(f))
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -67,18 +67,18 @@ fun interface LookupPublicKeysFromDIDDocument {
 interface SdJwtVcVerifier<out JWT> {
 
     /**
-     * Verifies an SD-JWT (in non enveloped, simple format)
-     * Typically, this is useful to Holder that wants to verify an issued SD-JWT
+     * Verifies an SD-JWT serialized using compact serialization.
+     * Typically, this is useful to Holder that wants to verify an issued SD-JWT.
      *
      * @param unverifiedSdJwt the SD-JWT to be verified
      * @return the verified SD-JWT, if valid. Otherwise, method could raise a [SdJwtVerificationException]
      * The verified SD-JWT will contain a [JWT][SdJwt.jwt] as both string and decoded payload
      */
-    suspend fun verifyIssuance(unverifiedSdJwt: String): Result<SdJwt<JWT>>
+    suspend fun verify(unverifiedSdJwt: String): Result<SdJwt<JWT>>
 
     /**
-     * Verifies an SD-JWT in JWS JSON general of flattened format as defined by RFC7515 and extended by SD-JWT
-     * specification
+     * Verifies an SD-JWT serialized using JWS JSON serialization (either general or flattened format) as defined by RFC7515
+     * and extended by SD-JWT specification.
      *
      * Typically, this is useful to Holder that wants to verify an issued SD-JWT
      *
@@ -89,65 +89,67 @@ interface SdJwtVcVerifier<out JWT> {
      * Otherwise, method could raise a [SdJwtVerificationException]
      * The verified SD-JWT will contain a [JWT][SdJwt.jwt] as both string and decoded payload
      */
-    suspend fun verifyIssuance(unverifiedSdJwt: JsonObject): Result<SdJwt<JWT>>
+    suspend fun verify(unverifiedSdJwt: JsonObject): Result<SdJwt<JWT>>
 
     /**
-     * Verifies a SD-JWT in Combined Presentation Format
-     * Typically, this is useful to Verifier that wants to verify presentation SD-JWT communicated by Holder
+     * Verifies a SD-JWT+KB serialized using compact serialization.
+     * Typically, this is useful to Verifier that want to verify presentation SD-JWT communicated by Holders.
      *
      * @param unverifiedSdJwt the SD-JWT to be verified
      * @param challenge verifier's challenge, expected to be found in KB-JWT (signed by wallet)
-     * @return the verified SD-JWT and KB-JWT, if valid. Otherwise, method could raise a [SdJwtVerificationException]
-     * The verified SD-JWT will the [JWT][SdJwt.jwt] and key binding JWT
+     * @return the verified SD-JWT and the KeyBinding JWT, if valid.
+     * Otherwise, method could raise a [SdJwtVerificationException]
+     * The verified SD-JWT will the [JWT][SdJwt.jwt] and KeyBinding JWT
      * are representing in both string and decoded payload.
      * Expected errors are reported via a [SdJwtVerificationException]
      */
-    suspend fun verifyPresentation(
+    suspend fun verifyWithKeyBinding(
         unverifiedSdJwt: String,
         challenge: JsonObject? = null,
-    ): Result<Pair<SdJwt<JWT>, JWT?>>
+    ): Result<Pair<SdJwt<JWT>, JWT>>
 
     /**
-     * Verifies a SD-JWT in Combined Presentation Format
-     * Typically, this is useful to Verifier that wants to verify presentation SD-JWT communicated by Holder
+     * Verifies a SD-JWT+KB in JWS JSON serialization.
+     * Typically, this is useful to Verifier that want to verify presentation SD-JWT communicated by Holders
      *
      * @param unverifiedSdJwt the SD-JWT to be verified in JWS JSON
      * @param challenge verifier's challenge, expected to be found in KB-JWT (signed by wallet)
-     * @return the verified SD-JWT and KB-JWT, if valid. Otherwise, method could raise a [SdJwtVerificationException]
-     * The verified SD-JWT will the [JWT][SdJwt.jwt] and key binding JWT
+     * @return the verified SD-JWT and KeyBinding JWT, if valid.
+     * Otherwise, method could raise a [SdJwtVerificationException]
+     * The verified SD-JWT will the [JWT][SdJwt.jwt] and KeyBinding JWT
      * are representing in both string and decoded payload.
      * Expected errors are reported via a [SdJwtVerificationException]
      */
-    suspend fun verifyPresentation(
+    suspend fun verifyWithKeyBinding(
         unverifiedSdJwt: JsonObject,
         challenge: JsonObject? = null,
-    ): Result<Pair<SdJwt<JWT>, JWT?>>
+    ): Result<Pair<SdJwt<JWT>, JWT>>
 
     companion object : SdJwtVcVerifierFactory<JwtAndClaims> by DefaultSdJwtVcFactory
 }
 
 fun <JWT, JWT1> SdJwtVcVerifier<JWT>.map(f: (JWT) -> JWT1): SdJwtVcVerifier<JWT1> {
     return object : SdJwtVcVerifier<JWT1> {
-        override suspend fun verifyIssuance(unverifiedSdJwt: String): Result<SdJwt<JWT1>> =
-            this@map.verifyIssuance(unverifiedSdJwt).map { sdJwt -> sdJwt.map(f) }
+        override suspend fun verify(unverifiedSdJwt: String): Result<SdJwt<JWT1>> =
+            this@map.verify(unverifiedSdJwt).map { sdJwt -> sdJwt.map(f) }
 
-        override suspend fun verifyIssuance(unverifiedSdJwt: JsonObject): Result<SdJwt<JWT1>> =
-            this@map.verifyIssuance(unverifiedSdJwt).map { sdJwt -> sdJwt.map(f) }
+        override suspend fun verify(unverifiedSdJwt: JsonObject): Result<SdJwt<JWT1>> =
+            this@map.verify(unverifiedSdJwt).map { sdJwt -> sdJwt.map(f) }
 
-        override suspend fun verifyPresentation(
+        override suspend fun verifyWithKeyBinding(
             unverifiedSdJwt: String,
             challenge: JsonObject?,
-        ): Result<Pair<SdJwt<JWT1>, JWT1?>> =
-            this@map.verifyPresentation(unverifiedSdJwt, challenge).map { (sdJwt, kbJwt) ->
-                sdJwt.map(f) to kbJwt?.let(f)
+        ): Result<Pair<SdJwt<JWT1>, JWT1>> =
+            this@map.verifyWithKeyBinding(unverifiedSdJwt, challenge).map { (sdJwt, kbJwt) ->
+                sdJwt.map(f) to f(kbJwt)
             }
 
-        override suspend fun verifyPresentation(
+        override suspend fun verifyWithKeyBinding(
             unverifiedSdJwt: JsonObject,
             challenge: JsonObject?,
-        ): Result<Pair<SdJwt<JWT1>, JWT1?>> =
-            this@map.verifyPresentation(unverifiedSdJwt, challenge).map { (sdJwt, kbJwt) ->
-                sdJwt.map(f) to kbJwt?.let(f)
+        ): Result<Pair<SdJwt<JWT1>, JWT1>> =
+            this@map.verifyWithKeyBinding(unverifiedSdJwt, challenge).map { (sdJwt, kbJwt) ->
+                sdJwt.map(f) to f(kbJwt)
             }
     }
 }
@@ -227,28 +229,30 @@ private class NimbusSdJwtVcVerifier(
         sdJwtVcSignatureVerifier(httpClientFactory, trust, lookup)
 
     private fun keyBindingVerifierForSdJwtVc(challenge: JsonObject?): KeyBindingVerifier.MustBePresentAndValid<NimbusSignedJWT> =
-        KeyBindingVerifier.mustBePresentAndValid(NimbusSdJwtOps.HolderPubKeyInConfirmationClaim, challenge)
+        with(NimbusSdJwtOps) {
+            KeyBindingVerifier.mustBePresentAndValid(HolderPubKeyInConfirmationClaim, challenge)
+        }
 
-    override suspend fun verifyIssuance(unverifiedSdJwt: String): Result<SdJwt<NimbusSignedJWT>> =
-        NimbusSdJwtOps.verifyIssuance(jwtSignatureVerifier, unverifiedSdJwt)
+    override suspend fun verify(unverifiedSdJwt: String): Result<SdJwt<NimbusSignedJWT>> =
+        NimbusSdJwtOps.verify(jwtSignatureVerifier, unverifiedSdJwt)
 
-    override suspend fun verifyIssuance(unverifiedSdJwt: JsonObject): Result<SdJwt<NimbusSignedJWT>> =
-        NimbusSdJwtOps.verifyIssuance(jwtSignatureVerifier, unverifiedSdJwt)
+    override suspend fun verify(unverifiedSdJwt: JsonObject): Result<SdJwt<NimbusSignedJWT>> =
+        NimbusSdJwtOps.verify(jwtSignatureVerifier, unverifiedSdJwt)
 
-    override suspend fun verifyPresentation(
+    override suspend fun verifyWithKeyBinding(
         unverifiedSdJwt: String,
         challenge: JsonObject?,
-    ): Result<Pair<SdJwt<NimbusSignedJWT>, NimbusSignedJWT?>> = coroutineScope {
+    ): Result<Pair<SdJwt<NimbusSignedJWT>, NimbusSignedJWT>> = coroutineScope {
         val keyBindingVerifier = keyBindingVerifierForSdJwtVc(challenge)
-        NimbusSdJwtOps.verifyPresentation(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt)
+        NimbusSdJwtOps.verify(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt)
     }
 
-    override suspend fun verifyPresentation(
+    override suspend fun verifyWithKeyBinding(
         unverifiedSdJwt: JsonObject,
         challenge: JsonObject?,
-    ): Result<Pair<SdJwt<NimbusSignedJWT>, NimbusSignedJWT?>> = coroutineScope {
+    ): Result<Pair<SdJwt<NimbusSignedJWT>, NimbusSignedJWT>> = coroutineScope {
         val keyBindingVerifier = keyBindingVerifierForSdJwtVc(challenge)
-        NimbusSdJwtOps.verifyPresentation(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt)
+        NimbusSdJwtOps.verify(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt)
     }
 }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -336,7 +336,7 @@ class VerifierActor(
     ).also { lastChallenge = it.challenge.asJson() }
 
     suspend fun acceptPresentation(unverifiedSdJwt: String) {
-        val (presented, _) = verifier.verifyWithKeyBinding(unverifiedSdJwt, lastChallenge).getOrThrow()
+        val (presented, _) = verifier.verify(unverifiedSdJwt, lastChallenge).getOrThrow()
         presented.prettyPrint { it.second }
         presentation = presented.ensureContainsWhatRequested()
         verifierDebug("Presentation accepted with SD Claims:")

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -90,7 +90,7 @@ class KeyBindingTest {
         assertEquals(emailCredential.email, selectivelyDisclosedClaims["email"]?.jsonPrimitive?.content)
 
         // Assert issuer verifier is able to verify JWT
-        val jwtClaims = assertNotNull(verifier.verifyIssuance(issuedSdJwtStr).getOrNull())
+        val jwtClaims = assertNotNull(verifier.verify(issuedSdJwtStr).getOrNull())
 
         // Extract and verify holder public key
         assertEquals(holderPubKey, HolderPubKeyInConfirmationClaim(jwtClaims.jwt.second))
@@ -281,7 +281,7 @@ class HolderActor(
 
     suspend fun storeCredential(sdJwt: String) {
         holderDebug("Storing issued SD-JWT ...")
-        verifier.verifyIssuance(sdJwt).fold(
+        verifier.verify(sdJwt).fold(
             onSuccess = { issued ->
                 credentialSdJwt = issued
                 holderDebug("Stored SD-JWT")
@@ -328,7 +328,7 @@ class VerifierActor(
     lookup: LookupPublicKeysFromDIDDocument,
 ) {
     private val verifier = DefaultSdJwtOps.usingDID(lookup)
-    private var lastChallenge: JsonObject? = null
+    private lateinit var lastChallenge: JsonObject
     private var presentation: SdJwt<JwtAndClaims>? = null
     fun query(): VerifierQuery = VerifierQuery(
         VerifierChallenge(Random.nextBytes(10).toString(), clientId, Instant.now()),
@@ -336,7 +336,7 @@ class VerifierActor(
     ).also { lastChallenge = it.challenge.asJson() }
 
     suspend fun acceptPresentation(unverifiedSdJwt: String) {
-        val (presented, _) = verifier.verifyPresentation(unverifiedSdJwt, lastChallenge).getOrThrow()
+        val (presented, _) = verifier.verifyWithKeyBinding(unverifiedSdJwt, lastChallenge).getOrThrow()
         presented.prettyPrint { it.second }
         presentation = presented.ensureContainsWhatRequested()
         verifierDebug("Presentation accepted with SD Claims:")

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -52,7 +52,7 @@ class PidDevVerificationTest :
         )
 
         val issuedSdJwt = try {
-            verifier.verifyIssuance(unverifiedSdJwtVc).getOrThrow()
+            verifier.verify(unverifiedSdJwtVc).getOrThrow()
         } catch (e: Throwable) {
             printError(unverifiedSdJwtVc, e)
             throw e

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Sample.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Sample.kt
@@ -123,5 +123,5 @@ suspend fun main() {
 
 suspend fun verifyIssuance(sdJwt: String, issuerPubKey: RSAKey): Result<SdJwt<SignedJWT>> = with(NimbusSdJwtOps) {
     val jwtVer = RSASSAVerifier(issuerPubKey).asJwtVerifier()
-    return verifyIssuance(jwtVer, sdJwt)
+    return verify(jwtVer, sdJwt)
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyIssuanceTest.kt
@@ -66,7 +66,7 @@ class SdJwtVerifierVerifyIssuanceTest {
         unverifiedSdJwt: JsonObject,
     ) {
         val verification =
-            DefaultSdJwtOps.verifyIssuance(jwtSignatureVerifier = jwtSignatureVerifier, unverifiedSdJwt = unverifiedSdJwt)
+            DefaultSdJwtOps.verify(jwtSignatureVerifier = jwtSignatureVerifier, unverifiedSdJwt = unverifiedSdJwt)
         assertTrue { verification.isSuccess }
     }
 
@@ -75,7 +75,7 @@ class SdJwtVerifierVerifyIssuanceTest {
         unverifiedSdJwt: String,
     ) {
         val verifiedSdJwt =
-            DefaultSdJwtOps.verifyIssuance(jwtSignatureVerifier = jwtSignatureVerifier, unverifiedSdJwt = unverifiedSdJwt).getOrThrow()
+            DefaultSdJwtOps.verify(jwtSignatureVerifier = jwtSignatureVerifier, unverifiedSdJwt = unverifiedSdJwt).getOrThrow()
 
         val sdJwtWithOutSigVerification =
             DefaultSdJwtOps.unverifiedIssuanceFrom(unverifiedSdJwt).getOrThrow()
@@ -123,7 +123,7 @@ class SdJwtVerifierVerifyIssuanceTest {
         jwtSignatureVerifier: JwtSignatureVerifier<JwtAndClaims>,
         unverifiedSdJwt: String,
     ) {
-        val verification = DefaultSdJwtOps.verifyIssuance(
+        val verification = DefaultSdJwtOps.verify(
             jwtSignatureVerifier = jwtSignatureVerifier,
             unverifiedSdJwt = unverifiedSdJwt,
         )
@@ -144,7 +144,7 @@ class SdJwtVerifierVerifyIssuanceTest {
         jwtSignatureVerifier: JwtSignatureVerifier<JwtAndClaims>,
         unverifiedSdJwt: JsonObject,
     ) {
-        val verification = DefaultSdJwtOps.verifyIssuance(
+        val verification = DefaultSdJwtOps.verify(
             jwtSignatureVerifier = jwtSignatureVerifier,
             unverifiedSdJwt = unverifiedSdJwt,
         )

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SpecExamples.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SpecExamples.kt
@@ -121,12 +121,11 @@ class SpecExamples {
     )
 
     private fun test(unverifiedSdJwt: String) = runTest {
-        DefaultSdJwtOps.verifyPresentation(
+        DefaultSdJwtOps.verify(
             DefaultSdJwtOps.NoSignatureValidation,
-            KeyBindingVerifier.MustNotBePresent,
             unverifiedSdJwt,
         ).getOrThrow()
-            .also { (sdJwt, _) -> sdJwt.printRecreated() }
+            .also { it.printRecreated() }
     }
 
     private fun SdJwt<JwtAndClaims>.printRecreated() {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleIssuanceSdJwtVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleIssuanceSdJwtVerification01.kt
@@ -25,6 +25,6 @@ val verifiedIssuanceSdJwt: SdJwt<SignedJWT> = runBlocking {
         val issuerKeyPair = loadRsaKey("/examplesIssuerKey.json")
         val jwtSignatureVerifier = RSASSAVerifier(issuerKeyPair).asJwtVerifier()
         val unverifiedIssuanceSdJwt = loadSdJwt("/exampleIssuanceSdJwt.txt")
-        verifyIssuance(jwtSignatureVerifier, unverifiedIssuanceSdJwt).getOrThrow()
+        verify(jwtSignatureVerifier, unverifiedIssuanceSdJwt).getOrThrow()
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExamplePresentationSdJwtVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExamplePresentationSdJwtVerification01.kt
@@ -25,10 +25,9 @@ val verifiedPresentationSdJwt: SdJwt<SignedJWT> = runBlocking {
         val issuerKeyPair = loadRsaKey("/examplesIssuerKey.json")
         val jwtSignatureVerifier = RSASSAVerifier(issuerKeyPair).asJwtVerifier()
         val unverifiedPresentationSdJwt = loadSdJwt("/examplePresentationSdJwt.txt")
-        val sdJwt = verify(
+        verify(
             jwtSignatureVerifier,
             unverifiedPresentationSdJwt,
         ).getOrThrow()
-        sdJwt
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExamplePresentationSdJwtVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExamplePresentationSdJwtVerification01.kt
@@ -25,9 +25,8 @@ val verifiedPresentationSdJwt: SdJwt<SignedJWT> = runBlocking {
         val issuerKeyPair = loadRsaKey("/examplesIssuerKey.json")
         val jwtSignatureVerifier = RSASSAVerifier(issuerKeyPair).asJwtVerifier()
         val unverifiedPresentationSdJwt = loadSdJwt("/examplePresentationSdJwt.txt")
-        val (sdJwt, _) = verifyPresentation(
+        val sdJwt = verify(
             jwtSignatureVerifier,
-            KeyBindingVerifier.MustNotBePresent,
             unverifiedPresentationSdJwt,
         ).getOrThrow()
         sdJwt

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -80,5 +80,5 @@ val sdJwtVcVerification = runBlocking {
     }
 
     val verifier = NimbusSdJwtOps.usingX5c { chain -> chain.firstOrNull() == certificate }
-    verifier.verifyIssuance(sdJwt)
+    verifier.verify(sdJwt)
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
@@ -203,7 +203,7 @@ class SdJwtVcIssuanceTest {
             lXQ~WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgImlzX292ZXJfNjUiLCB0cnVlXQ~
         """.trimIndent().removeNewLine()
 
-        val sdJwt = sdJwtVcVerifier.verifyIssuance(unverified).getOrThrow()
+        val sdJwt = sdJwtVcVerifier.verify(unverified).getOrThrow()
         val jwsJson = with(DefaultSdJwtOps) {
             sdJwt.asJwsJsonObject(JwsSerializationOption.Flattened)
         }
@@ -243,7 +243,7 @@ class SdJwtVcIssuanceTest {
             """.trimIndent().removeNewLine()
 
         val (sdJwt, kbJwtAndClaims) =
-            sdJwtVcVerifier.verifyPresentation(unverified).getOrThrow()
+            sdJwtVcVerifier.verifyWithKeyBinding(unverified).getOrThrow()
         val (kbJwt, kbJwtClaims) = assertNotNull(kbJwtAndClaims)
 
         println(json.encodeToString(JsonObject(kbJwtClaims)))
@@ -272,7 +272,7 @@ class SdJwtVcIssuanceTest {
     //
 
     private suspend fun verify(issuedSdJwtStr: String) {
-        val verified: SdJwt<JwtAndClaims> = sdJwtVcVerifier.verifyIssuance(issuedSdJwtStr).getOrThrow()
+        val verified: SdJwt<JwtAndClaims> = sdJwtVcVerifier.verify(issuedSdJwtStr).getOrThrow()
 
         // Check Header
         val jwsHeader = SignedJWT.parse(verified.jwt.first).header

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
@@ -242,8 +242,7 @@ class SdJwtVcIssuanceTest {
                 EOtnT09YNGp9nZbETjor3nCzM0J0MvQ
             """.trimIndent().removeNewLine()
 
-        val (sdJwt, kbJwtAndClaims) =
-            sdJwtVcVerifier.verifyWithKeyBinding(unverified).getOrThrow()
+        val (sdJwt, kbJwtAndClaims) = sdJwtVcVerifier.verify(unverified, null).getOrThrow()
         val (kbJwt, kbJwtClaims) = assertNotNull(kbJwtAndClaims)
 
         println(json.encodeToString(JsonObject(kbJwtClaims)))

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -135,14 +135,14 @@ class SdJwtVcVerifierTest {
     fun `SdJwtVcVerifier should verify an SD-JWT-VC when iss is HTTPS url using kid`() = runTest {
         val unverifiedSdJwt = SampleIssuer.issueUsingKid(kid = SampleIssuer.KEY_ID)
         val verifier = DefaultSdJwtOps.usingIssuerMetadata { HttpMock.clientReturning(SampleIssuer.issuerMeta) }
-        verifier.verifyIssuance(unverifiedSdJwt).getOrThrow()
+        verifier.verify(unverifiedSdJwt).getOrThrow()
     }
 
     @Test
     fun `SdJwtVcVerifier should verify an SD-JWT-VC when iss is HTTPS url and no kid`() = runTest {
         val unverifiedSdJwt = SampleIssuer.issueUsingKid(kid = null)
         val verifier = DefaultSdJwtOps.usingIssuerMetadata { HttpMock.clientReturning(SampleIssuer.issuerMeta) }
-        verifier.verifyIssuance(unverifiedSdJwt).getOrThrow()
+        verifier.verify(unverifiedSdJwt).getOrThrow()
     }
 
     @Test
@@ -151,7 +151,7 @@ class SdJwtVcVerifierTest {
         val unverifiedSdJwt = SampleIssuer.issueUsingKid("wrong kid")
         val verifier = DefaultSdJwtOps.usingIssuerMetadata { HttpMock.clientReturning(SampleIssuer.issuerMeta) }
         try {
-            verifier.verifyIssuance(unverifiedSdJwt).getOrThrow()
+            verifier.verify(unverifiedSdJwt).getOrThrow()
         } catch (exception: SdJwtVerificationException) {
             assertEquals(VerificationError.InvalidJwt, exception.reason)
         }
@@ -184,6 +184,6 @@ class SdJwtVcVerifierTest {
 
             val serialized =
                 with(NimbusSdJwtOps) { sdJwt.serialize() }
-            verifier.verifyIssuance(serialized).getOrThrow()
+            verifier.verify(serialized).getOrThrow()
         }
 }


### PR DESCRIPTION
This PR defines the methods of `SdJwtVerifier` and `SdJwtVcVerifier` more appropriate.

As per spec, the verifier distinguish between SD-JWT and SD-JWT+KB formats.
When verifying an SD-JWT+KB, a `KeyBindingVerifier.MustBePresentAndValid` instance is expected, and the return type of methods return a non-nullable KeyBinding JWT.

This additionally unlocks the possibility to verify presented SD-JWTs that do not contain KeyBinding JWTs. Previously this wasn't possible (or rather, previously one would have to call the `verifyIssuance` methods).

Closes #293 