### PR TITLE
Expose SdJwtVcVerifierFactory as value of XyzOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,22 +441,23 @@ val sdJwtVcVerification = runBlocking {
         X509CertUtils.parse(holder.encoded)
     }
 
-    val sdJwt = run {
-        val spec = sdJwt {
-            claim(RFC7519.ISSUER, issuer.toExternalForm())
-            claim(SdJwtVcSpec.VCT, "urn:credential:sample")
-        }
-        with(NimbusSdJwtOps) {
+    with(NimbusSdJwtOps) {
+        val sdJwt = run {
+            val spec = sdJwt {
+                claim(RFC7519.ISSUER, issuer.toExternalForm())
+                claim(SdJwtVcSpec.VCT, "urn:credential:sample")
+            }
+
             val signer = issuer(signer = ECDSASigner(key), signAlgorithm = JWSAlgorithm.ES512) {
                 type(JOSEObjectType("vc+sd-jwt"))
                 x509CertChain(listOf(Base64.encode(certificate.encoded)))
             }
             signer.issue(spec).getOrThrow().serialize()
         }
-    }
 
-    val verifier = NimbusSdJwtOps.usingX5c { chain -> chain.firstOrNull() == certificate }
-    verifier.verify(sdJwt)
+        val verifier = SdJwtVcVerifier.usingX5c { chain -> chain.firstOrNull() == certificate }
+        verifier.verify(sdJwt)
+    }
 }
 ```
 

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOps.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOps.kt
@@ -24,8 +24,7 @@ object DefaultSdJwtOps :
     SdJwtVerifier<JwtAndClaims> by DefaultVerifier,
     SdJwtSerializationOps<JwtAndClaims> by DefaultSerializationOps,
     SdJwtPresentationOps<JwtAndClaims> by DefaultPresentationOps,
-    UnverifiedIssuanceFrom<JwtAndClaims> by DefaultSdJwtUnverifiedIssuanceFrom,
-    SdJwtVcVerifierFactory<JwtAndClaims> by DefaultSdJwtVcFactory {
+    UnverifiedIssuanceFrom<JwtAndClaims> by DefaultSdJwtUnverifiedIssuanceFrom {
 
     val NoSignatureValidation: JwtSignatureVerifier<JwtAndClaims> =
         JwtSignatureVerifier { unverifiedJwt ->
@@ -35,6 +34,8 @@ object DefaultSdJwtOps :
 
     val KeyBindingVerifierMustBePresent: KeyBindingVerifier<JwtAndClaims> =
         KeyBindingVerifier.mustBePresent(NoSignatureValidation)
+
+    val SdJwtVcVerifier: SdJwtVcVerifierFactory<JwtAndClaims> = DefaultSdJwtVcFactory
 }
 
 private val DefaultSerializationOps = SdJwtSerializationOps<JwtAndClaims>(

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -154,8 +154,7 @@ private object NimbusSdJwtIssuerFactory {
 object NimbusSdJwtOps :
     SdJwtSerializationOps<NimbusSignedJWT> by NimbusSerializationOps,
     SdJwtPresentationOps<NimbusSignedJWT> by NimbusPresentationOps,
-    SdJwtVerifier<NimbusSignedJWT> by NimbusVerifier,
-    SdJwtVcVerifierFactory<NimbusSignedJWT> by NimbusSdJwtVcFactory {
+    SdJwtVerifier<NimbusSignedJWT> by NimbusVerifier {
 
     /**
      * Factory method for creating a [KeyBindingVerifier] which applies the rules described in [keyBindingJWTProcess].
@@ -287,6 +286,8 @@ object NimbusSdJwtOps :
             }
         }
     }
+
+    val SdJwtVcVerifier: SdJwtVcVerifierFactory<NimbusSignedJWT> = NimbusSdJwtVcFactory
 }
 
 private val NimbusSerializationOps: SdJwtSerializationOps<NimbusSignedJWT> =

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -264,8 +264,8 @@ object NimbusSdJwtOps :
         NimbusSdJwtIssuerFactory.createIssuer(sdJwtFactory, signer, signAlgorithm, jwsHeaderCustomization)
 
     fun kbJwtIssuer(
-        signAlgorithm: NimbusJWSAlgorithm,
         signer: NimbusJWSSigner,
+        signAlgorithm: NimbusJWSAlgorithm,
         publicKey: NimbusAsymmetricJWK,
         claimSetBuilderAction: NimbusJWTClaimsSet.Builder.() -> Unit = {},
     ): BuildKbJwt = BuildKbJwt { sdJwtDigest ->

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -307,7 +307,7 @@ class HolderActor(
         checkNotNull(presentationSdJwt)
 
         return with(NimbusSdJwtOps) {
-            val buildKbJwt = kbJwtIssuer(JWSAlgorithm.ES256, ECDSASigner(holderKey), holderKey.toPublicJWK()) {
+            val buildKbJwt = kbJwtIssuer(ECDSASigner(holderKey), JWSAlgorithm.ES256, holderKey.toPublicJWK()) {
                 audience(verifierQuery.challenge.aud)
                 claim("nonce", verifierQuery.challenge.nonce)
                 issueTime(Date.from(Instant.ofEpochSecond(verifierQuery.challenge.iat)))

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -52,7 +52,7 @@ class KeyBindingTest {
 
     private val issuer = IssuerActor(genKey("issuer"))
     private val lookup = LookupPublicKeysFromDIDDocument { _, _ -> listOf(issuer.issuerKey.toPublicJWK()) }
-    private val verifier = DefaultSdJwtOps.usingDID(lookup)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingDID(lookup)
     private val holder = HolderActor(genKey("holder"), lookup)
 
     /**
@@ -270,7 +270,7 @@ class HolderActor(
     private val holderKey: ECKey,
     lookup: LookupPublicKeysFromDIDDocument,
 ) {
-    private val verifier = DefaultSdJwtOps.usingDID(lookup)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingDID(lookup)
 
     fun pubKey(): AsymmetricJWK = holderKey.toPublicJWK()
 
@@ -327,7 +327,7 @@ class VerifierActor(
     private val expectedNumberOfDisclosures: Int,
     lookup: LookupPublicKeysFromDIDDocument,
 ) {
-    private val verifier = DefaultSdJwtOps.usingDID(lookup)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingDID(lookup)
     private lateinit var lastChallenge: JsonObject
     private var presentation: SdJwt<JwtAndClaims>? = null
     fun query(): VerifierQuery = VerifierQuery(

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -46,7 +46,7 @@ class PidDevVerificationTest :
     fun testPy() = doTest(pid2, enableLogging = false)
 
     private fun doTest(unverifiedSdJwtVc: String, enableLogging: Boolean = false) = runTest {
-        val verifier = DefaultSdJwtOps.usingX5cOrIssuerMetadata(
+        val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingX5cOrIssuerMetadata(
             httpClientFactory = { createHttpClient(enableLogging = enableLogging) },
             x509CertificateTrust = { _ -> true },
         )

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/StandardSerializationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/StandardSerializationTest.kt
@@ -35,8 +35,8 @@ class StandardSerializationTest {
     private val keyBindingSigner: BuildKbJwt by lazy {
         val holderKey = ECKeyGenerator(Curve.P_256).generate()
         NimbusSdJwtOps.kbJwtIssuer(
-            signAlgorithm = JWSAlgorithm.ES256,
             signer = ECDSASigner(holderKey),
+            signAlgorithm = JWSAlgorithm.ES256,
             publicKey = holderKey.toPublicJWK(),
         )
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -65,20 +65,21 @@ val sdJwtVcVerification = runBlocking {
         X509CertUtils.parse(holder.encoded)
     }
 
-    val sdJwt = run {
-        val spec = sdJwt {
-            claim(RFC7519.ISSUER, issuer.toExternalForm())
-            claim(SdJwtVcSpec.VCT, "urn:credential:sample")
-        }
-        with(NimbusSdJwtOps) {
+    with(NimbusSdJwtOps) {
+        val sdJwt = run {
+            val spec = sdJwt {
+                claim(RFC7519.ISSUER, issuer.toExternalForm())
+                claim(SdJwtVcSpec.VCT, "urn:credential:sample")
+            }
+
             val signer = issuer(signer = ECDSASigner(key), signAlgorithm = JWSAlgorithm.ES512) {
                 type(JOSEObjectType("vc+sd-jwt"))
                 x509CertChain(listOf(Base64.encode(certificate.encoded)))
             }
             signer.issue(spec).getOrThrow().serialize()
         }
-    }
 
-    val verifier = NimbusSdJwtOps.usingX5c { chain -> chain.firstOrNull() == certificate }
-    verifier.verify(sdJwt)
+        val verifier = SdJwtVcVerifier.usingX5c { chain -> chain.firstOrNull() == certificate }
+        verifier.verify(sdJwt)
+    }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
@@ -149,7 +149,7 @@ class SdJwtVcIssuanceTest {
 
     private val issuingService = SdJwtVCIssuer(IssuerSampleCfg)
 
-    val sdJwtVcVerifier = DefaultSdJwtOps.usingIssuerMetadata {
+    val sdJwtVcVerifier = DefaultSdJwtOps.SdJwtVcVerifier.usingIssuerMetadata {
         val jwksAsJson = JWKSet(issuingService.config.issuerKey.toPublicJWK()).toString()
         val issuerMetadata = SdJwtVcIssuerMetadata(
             issuer = issuingService.config.issuer,

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -134,14 +134,14 @@ class SdJwtVcVerifierTest {
     @Test
     fun `SdJwtVcVerifier should verify an SD-JWT-VC when iss is HTTPS url using kid`() = runTest {
         val unverifiedSdJwt = SampleIssuer.issueUsingKid(kid = SampleIssuer.KEY_ID)
-        val verifier = DefaultSdJwtOps.usingIssuerMetadata { HttpMock.clientReturning(SampleIssuer.issuerMeta) }
+        val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingIssuerMetadata { HttpMock.clientReturning(SampleIssuer.issuerMeta) }
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
 
     @Test
     fun `SdJwtVcVerifier should verify an SD-JWT-VC when iss is HTTPS url and no kid`() = runTest {
         val unverifiedSdJwt = SampleIssuer.issueUsingKid(kid = null)
-        val verifier = DefaultSdJwtOps.usingIssuerMetadata { HttpMock.clientReturning(SampleIssuer.issuerMeta) }
+        val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingIssuerMetadata { HttpMock.clientReturning(SampleIssuer.issuerMeta) }
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
 
@@ -149,7 +149,7 @@ class SdJwtVcVerifierTest {
     fun `SdJwtVcVerifier should not verify an SD-JWT-VC when iss is HTTPS url using wrong kid`() = runTest {
         // In case the issuer uses the KID
         val unverifiedSdJwt = SampleIssuer.issueUsingKid("wrong kid")
-        val verifier = DefaultSdJwtOps.usingIssuerMetadata { HttpMock.clientReturning(SampleIssuer.issuerMeta) }
+        val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingIssuerMetadata { HttpMock.clientReturning(SampleIssuer.issuerMeta) }
         try {
             verifier.verify(unverifiedSdJwt).getOrThrow()
         } catch (exception: SdJwtVerificationException) {
@@ -177,7 +177,7 @@ class SdJwtVcVerifierTest {
                 signer.issue(spec).getOrThrow()
             }
 
-            val verifier = DefaultSdJwtOps.usingDID { did, _ ->
+            val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingDID { did, _ ->
                 assertEquals(didJwk, did)
                 listOf(key.toPublicJWK())
             }


### PR DESCRIPTION
Exposed `SdJwtVcVerifierFactory` as a value of 
- `DefaultSdJwtOps` 
- `NimbusSdJwtOps`

Previously, the above objects where implementing the factory, but naming was not intuitive.