### PR TITLE
Improve KeyBinding JWT validation errors

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project properties
 group=eu.europa.ec.eudi
-version=0.11.1-SNAPSHOT
+version=0.12.0-SNAPSHOT
 
 # Kotlin configuration
 kotlin.code.style=official

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyPresentationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierVerifyPresentationTest.kt
@@ -94,7 +94,12 @@ class SdJwtVerifierVerifyPresentationTest {
     fun `when sd-jwt has an valid jwt, no disclosures and invalid keyBinding verify should return InvalidKeyBindingJwt`() =
         runTest {
             verifyPresentationExpectingError(
-                VerificationError.KeyBindingFailed(KeyBindingError.InvalidKeyBindingJwt),
+                VerificationError.KeyBindingFailed(
+                    KeyBindingError.InvalidKeyBindingJwt(
+                        "Could not verify KeyBinding JWT",
+                        SdJwtVerificationException(reason = VerificationError.InvalidJwt("Serialized JWT must have exactly 3 parts")),
+                    ),
+                ),
                 NoSignatureValidation,
                 KeyBindingVerifierMustBePresent,
                 "$jwt~hb",
@@ -105,7 +110,7 @@ class SdJwtVerifierVerifyPresentationTest {
     fun `when sd-jwt has an valid jwt, no disclosures and keyBinding without 'sd_hash' verify fails with InvalidKeyBindingJwt`() =
         runTest {
             verifyPresentationExpectingError(
-                VerificationError.KeyBindingFailed(KeyBindingError.InvalidKeyBindingJwt),
+                VerificationError.KeyBindingFailed(KeyBindingError.InvalidKeyBindingJwt("sd_hash claim contains an invalid value")),
                 NoSignatureValidation,
                 KeyBindingVerifierMustBePresent,
                 "$jwt~$jwt",
@@ -155,7 +160,7 @@ class SdJwtVerifierVerifyPresentationTest {
     fun `when sd-jwt has an valid jwt, valid disclosures and keyBinding without 'sd_hash' verify fails with InvalidKeyBindingJwt`() =
         runTest {
             verifyPresentationExpectingError(
-                VerificationError.KeyBindingFailed(KeyBindingError.InvalidKeyBindingJwt),
+                VerificationError.KeyBindingFailed(KeyBindingError.InvalidKeyBindingJwt("sd_hash claim contains an invalid value")),
                 NoSignatureValidation,
                 KeyBindingVerifierMustBePresent,
                 "$jwt~$d1~$jwt",


### PR DESCRIPTION
* Reworks `KeyBindingError` sealed hierarchy
* Introduces new errors
* Converts some errors to data classes with extra properties (they were previously data objects)

Due to the nature of the changes minor public api breaking changes are introduced.
As a result version is being bumped to `0.12.0-SNAPSHOT`.

Closes #322 