### PR TITLE
Minimize dependency to JVM. Introduce Hashes & Random

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DisclosureDigest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DisclosureDigest.kt
@@ -15,8 +15,6 @@
  */
 package eu.europa.ec.eudi.sdjwt
 
-import java.security.MessageDigest
-
 /**
  * The digest of a [disclosure][Disclosure]
  */
@@ -56,9 +54,19 @@ value class DisclosureDigest private constructor(val value: String) {
          *
          * @return the [DisclosureDigest] of the given [value]
          */
-        fun digest(hashingAlgorithm: HashAlgorithm, value: String): Result<DisclosureDigest> = runCatching {
-            val hashFunction = MessageDigest.getInstance(hashingAlgorithm.alias.uppercase())
-            val digest = hashFunction.digest(value.encodeToByteArray())
+        fun digest(hashingAlgorithm: HashAlgorithm, value: String): Result<DisclosureDigest> =
+            digestInternal(platform().hashes, hashingAlgorithm, value)
+
+        /**
+         * Internal version of digest that takes a Platform parameter
+         */
+        internal fun digestInternal(
+            hashes: Hashes,
+            hashingAlgorithm: HashAlgorithm,
+            value: String,
+        ): Result<DisclosureDigest> = runCatching {
+            val input = value.encodeToByteArray()
+            val digest = hashes.digest(hashingAlgorithm, input)
             DisclosureDigest(Base64UrlNoPadding.encode(digest))
         }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Hashes.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Hashes.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt
+
+internal interface Hashes {
+    fun sha256(input: ByteArray): ByteArray
+    fun sha384(input: ByteArray): ByteArray
+    fun sha512(input: ByteArray): ByteArray
+
+    @Suppress("ktlint:standard:function-naming")
+    fun sha3_256(input: ByteArray): ByteArray
+
+    @Suppress("ktlint:standard:function-naming")
+    fun sha3_384(input: ByteArray): ByteArray
+
+    @Suppress("ktlint:standard:function-naming")
+    fun sha3_512(input: ByteArray): ByteArray
+}
+
+internal fun Hashes.digest(hashAlgorithm: HashAlgorithm, input: ByteArray): ByteArray =
+    when (hashAlgorithm) {
+        HashAlgorithm.SHA_256 -> sha256(input)
+        HashAlgorithm.SHA_384 -> sha384(input)
+        HashAlgorithm.SHA_512 -> sha512(input)
+        HashAlgorithm.SHA3_256 -> sha3_256(input)
+        HashAlgorithm.SHA3_384 -> sha3_384(input)
+        HashAlgorithm.SHA3_512 -> sha3_512(input)
+    }
+
+internal object JvmAndAndroidHashes : Hashes {
+
+    override fun sha256(input: ByteArray): ByteArray =
+        java.security.MessageDigest.getInstance("SHA-256").digest(input)
+
+    override fun sha384(input: ByteArray): ByteArray =
+        java.security.MessageDigest.getInstance("SHA-384").digest(input)
+
+    override fun sha512(input: ByteArray): ByteArray =
+        java.security.MessageDigest.getInstance("SHA-512").digest(input)
+
+    override fun sha3_256(input: ByteArray): ByteArray =
+        java.security.MessageDigest.getInstance("SHA3-256").digest(input)
+
+    override fun sha3_384(input: ByteArray): ByteArray =
+        java.security.MessageDigest.getInstance("SHA3-384").digest(input)
+
+    override fun sha3_512(input: ByteArray): ByteArray =
+        java.security.MessageDigest.getInstance("SHA3-512").digest(input)
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Platform.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Platform.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt
+
+internal interface Platform {
+    val hashes: Hashes
+    val random: Random
+}
+
+internal fun platform(): Platform = JvmAndAndroidPlatform
+
+internal object JvmAndAndroidPlatform : Platform {
+
+    override val hashes: Hashes
+        get() = JvmAndAndroidHashes
+
+    override val random: Random
+        get() = JvmAndAndroidSecureRandom
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Random.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Random.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt
+
+import java.security.SecureRandom
+
+internal interface Random {
+
+    fun nextBytesCopyTo(bytes: ByteArray)
+}
+
+internal object JvmAndAndroidSecureRandom : Random {
+    override fun nextBytesCopyTo(bytes: ByteArray) {
+        SecureRandom().nextBytes(bytes)
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SaltProvider.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SaltProvider.kt
@@ -15,8 +15,6 @@
  */
 package eu.europa.ec.eudi.sdjwt
 
-import java.security.SecureRandom
-
 /**
  * An interface for generating [Salt] values.
  */
@@ -36,7 +34,7 @@ fun interface SaltProvider {
          */
         val Default: SaltProvider by lazy { randomSaltProvider(16) }
 
-        private val secureRandom: SecureRandom = SecureRandom()
+        private val secureRandom: Random = platform().random
 
         /**
          * Creates a salt provider which generates random [Salt] values
@@ -47,7 +45,7 @@ fun interface SaltProvider {
          */
         fun randomSaltProvider(numberOfBytes: Int): SaltProvider =
             SaltProvider {
-                val randomByteArray: ByteArray = ByteArray(numberOfBytes).also { secureRandom.nextBytes(it) }
+                val randomByteArray: ByteArray = ByteArray(numberOfBytes).also { secureRandom.nextBytesCopyTo(it) }
                 Base64UrlNoPadding.encode(randomByteArray)
             }
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/JvmAndAndroidHashesTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/JvmAndAndroidHashesTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JvmAndAndroidHashesTest {
+
+    @Test
+    fun testSha256() {
+        val input = "test".encodeToByteArray()
+        val expected = Base64UrlNoPadding.encode(java.security.MessageDigest.getInstance("SHA-256").digest(input))
+        val actual = Base64UrlNoPadding.encode(JvmAndAndroidHashes.sha256(input))
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testSha384() {
+        val input = "test".encodeToByteArray()
+        val expected = Base64UrlNoPadding.encode(java.security.MessageDigest.getInstance("SHA-384").digest(input))
+        val actual = Base64UrlNoPadding.encode(JvmAndAndroidHashes.sha384(input))
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testSha512() {
+        val input = "test".encodeToByteArray()
+        val expected = Base64UrlNoPadding.encode(java.security.MessageDigest.getInstance("SHA-512").digest(input))
+        val actual = Base64UrlNoPadding.encode(JvmAndAndroidHashes.sha512(input))
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testSha3_256() {
+        val input = "test".encodeToByteArray()
+        val expected = Base64UrlNoPadding.encode(java.security.MessageDigest.getInstance("SHA3-256").digest(input))
+        val actual = Base64UrlNoPadding.encode(JvmAndAndroidHashes.sha3_256(input))
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testSha3_384() {
+        val input = "test".encodeToByteArray()
+        val expected = Base64UrlNoPadding.encode(java.security.MessageDigest.getInstance("SHA3-384").digest(input))
+        val actual = Base64UrlNoPadding.encode(JvmAndAndroidHashes.sha3_384(input))
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testSha3_512() {
+        val input = "test".encodeToByteArray()
+        val expected = Base64UrlNoPadding.encode(java.security.MessageDigest.getInstance("SHA3-512").digest(input))
+        val actual = Base64UrlNoPadding.encode(JvmAndAndroidHashes.sha3_512(input))
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
This PR attempts to minimize dependency to JVM-specific clases.

Introduces
- `Hashes` interface
- `Random` interface
- `Plarform` interface, which includes a `hashes` and `random` attributes

For the above, JVM-speiciic implementations are provided

In addition there is a global factory method introduced `plarfrom: Platfrom()` which provides the instance of the platfrom.

With these changes, public classes of the library depend on the `Plarform` (and `Hashes` and `Random`) rather depending directly to JVM-specific code

No breaking changes to the public API