### PR TITLE
Minimize dependency to JVM. Use kotlinx.datetime instead of java.time

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ import eu.europa.ec.eudi.sdjwt.RFC7519
 import eu.europa.ec.eudi.sdjwt.SdJwtVcSpec
 import eu.europa.ec.eudi.sdjwt.sdJwt
 import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import kotlinx.datetime.toJavaInstant
 import org.bouncycastle.asn1.DERSequence
 import org.bouncycastle.asn1.x509.Extension
 import org.bouncycastle.asn1.x509.GeneralName
@@ -409,11 +411,9 @@ import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import java.math.BigInteger
 import java.net.URL
-import java.time.Clock
 import java.util.*
 import javax.security.auth.x500.X500Principal
 import kotlin.time.Duration.Companion.days
-import kotlin.time.toJavaDuration
 -->
 
 ```kotlin
@@ -421,16 +421,15 @@ val sdJwtVcVerification = runBlocking {
     val issuer = URL("https://issuer.example.com")
     val key = ECKeyGenerator(Curve.P_521).generate()
     val certificate = run {
-        val clock = Clock.systemDefaultZone()
-        val issuedAt = clock.instant()
-        val expiresAt = issuedAt + 365.days.toJavaDuration()
+        val issuedAt = Clock.System.now()
+        val expiresAt = issuedAt.plus(365.days)
         val subject = X500Principal("CN=${issuer.host}")
         val signer = JcaContentSignerBuilder("SHA256withECDSA").build(key.toECPrivateKey())
         val holder = JcaX509v3CertificateBuilder(
             subject,
             BigInteger.ONE,
-            Date.from(issuedAt),
-            Date.from(expiresAt),
+            Date.from(issuedAt.toJavaInstant()),
+            Date.from(expiresAt.toJavaInstant()),
             subject,
             key.toECPublicKey(),
         ).addExtension(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     api(libs.ktor.client.content.negotiation)
     api(libs.ktor.client.serialization)
     api(libs.ktor.serialization.kotlinx.json)
+    testImplementation(libs.kotlinx.datetime)
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.kotlinx.coroutines.debug)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ foojay = "0.8.0"
 spotless = "6.25.0"
 java = "17"
 kotlinxSerialization = "1.7.3"
+kotlinxDatetime = "0.6.2"
 nimbusJoseWwt = "9.47"
 ktlintVersion = "0.50.0"
 sonarqube = "6.0.1.5171"
@@ -19,6 +20,7 @@ bouncyCastle = "1.79"
 
 [libraries]
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbusJoseWwt" }
 tink = { module = "com.google.crypto.tink:tink", version.ref = "tink" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegrationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegrationTest.kt
@@ -25,8 +25,8 @@ import com.nimbusds.jose.jwk.gen.OctetSequenceKeyGenerator
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
 import com.nimbusds.jwt.SignedJWT
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import org.bouncycastle.jce.provider.BouncyCastleProvider
-import java.time.Clock
 import java.util.*
 import kotlin.onFailure
 import kotlin.test.Test
@@ -84,7 +84,7 @@ private data class Context(
 
 private fun createContext(algorithm: JWSAlgorithm): Context = with(NimbusSdJwtOps) {
     val keyId = UUID.randomUUID().toString()
-    val issuedAt = Date(Clock.systemDefaultZone().millis())
+    val issuedAt = Date(Clock.System.now().toEpochMilliseconds())
 
     when (algorithm) {
         in JWSAlgorithm.Family.EC -> {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PresentationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PresentationTest.kt
@@ -26,9 +26,9 @@ import eu.europa.ec.eudi.sdjwt.examples.complexStructuredSdJwt
 import eu.europa.ec.eudi.sdjwt.examples.sdJwtVcDataV2
 import eu.europa.ec.eudi.sdjwt.vc.ClaimPath
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
-import java.time.Instant
 import kotlin.test.*
 
 class PresentationTest {
@@ -122,7 +122,7 @@ class PresentationTest {
             val sdJwt = run {
                 val spec = sdJwt {
                     claim("iss", "foo")
-                    claim("iat", Instant.now().epochSecond)
+                    claim("iat", Clock.System.now().epochSeconds)
                 }
                 issuer.issue(spec).getOrThrow().also {
                     assertTrue { it.disclosures.isEmpty() }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -27,6 +27,8 @@ import eu.europa.ec.eudi.sdjwt.RFC7519
 import eu.europa.ec.eudi.sdjwt.SdJwtVcSpec
 import eu.europa.ec.eudi.sdjwt.sdJwt
 import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import kotlinx.datetime.toJavaInstant
 import org.bouncycastle.asn1.DERSequence
 import org.bouncycastle.asn1.x509.Extension
 import org.bouncycastle.asn1.x509.GeneralName
@@ -35,26 +37,23 @@ import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import java.math.BigInteger
 import java.net.URL
-import java.time.Clock
 import java.util.*
 import javax.security.auth.x500.X500Principal
 import kotlin.time.Duration.Companion.days
-import kotlin.time.toJavaDuration
 
 val sdJwtVcVerification = runBlocking {
     val issuer = URL("https://issuer.example.com")
     val key = ECKeyGenerator(Curve.P_521).generate()
     val certificate = run {
-        val clock = Clock.systemDefaultZone()
-        val issuedAt = clock.instant()
-        val expiresAt = issuedAt + 365.days.toJavaDuration()
+        val issuedAt = Clock.System.now()
+        val expiresAt = issuedAt.plus(365.days)
         val subject = X500Principal("CN=${issuer.host}")
         val signer = JcaContentSignerBuilder("SHA256withECDSA").build(key.toECPrivateKey())
         val holder = JcaX509v3CertificateBuilder(
             subject,
             BigInteger.ONE,
-            Date.from(issuedAt),
-            Date.from(expiresAt),
+            Date.from(issuedAt.toJavaInstant()),
+            Date.from(expiresAt.toJavaInstant()),
             subject,
             key.toECPublicKey(),
         ).addExtension(

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
@@ -24,11 +24,11 @@ import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.sdjwt.*
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
 import java.net.URI
-import java.time.Instant
-import java.time.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -46,8 +46,8 @@ private class SdJwtVCIssuer(val config: IssuerConfig) {
     suspend fun issue(holderData: IdentityCredential, holderPubKey: JWK): SdJwt<SignedJWT> {
         val sdJwtSpec = holderData.sdJwtSpec(
             holderPubKey,
-            iat = Instant.ofEpochSecond(1683000000),
-            exp = Instant.ofEpochSecond(1883000000),
+            iat = Instant.fromEpochSeconds(1683000000),
+            exp = Instant.fromEpochSeconds(1883000000),
         )
         return issuer.issue(sdJwtSpec).getOrThrow()
     }
@@ -63,8 +63,8 @@ private class SdJwtVCIssuer(val config: IssuerConfig) {
             //
             claim("iss", config.issuer.toASCIIString())
             claim(SdJwtVcSpec.VCT, config.vct.toASCIIString())
-            claim("iat", iat.epochSecond)
-            exp?.let { claim("exp", it.epochSecond) }
+            claim("iat", iat.epochSeconds)
+            exp?.let { claim("exp", it.epochSeconds) }
             cnf(holderPubKey)
 
             //
@@ -119,7 +119,7 @@ private val JohnDoe = IdentityCredential(
         region = "Anystate",
         country = "US",
     ),
-    birthDate = LocalDate.of(1940, 1, 1),
+    birthDate = LocalDate(1940, 1, 1),
     isOver18 = true,
     isOver21 = true,
     isOver65 = true,

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -32,10 +32,10 @@ import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.sdjwt.*
 import io.ktor.http.*
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import java.net.URI
-import java.time.Instant
 import kotlin.io.encoding.Base64
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -67,7 +67,7 @@ private object SampleIssuer {
         val issuer = sdJwtVcIssuer(kid)
         val sdJwtSpec = sdJwt {
             claim(RFC7519.ISSUER, issuerMeta.issuer.toASCIIString())
-            claim(RFC7519.ISSUED_AT, Instant.now().epochSecond)
+            claim(RFC7519.ISSUED_AT, Clock.System.now().epochSeconds)
             claim(SdJwtVcSpec.VCT, "urn:credential:sample")
             sdClaim("foo", "bar")
         }


### PR DESCRIPTION
This PR replaces some usages of java.time classes with the equivalent classes from kotlinx.datetime library.

Changes affect only tests, thus there aren't breaking changes to the public API