### PR TITLE
Remove redundant plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,16 +7,14 @@ import java.net.URI
 plugins {
     base
     `java-library`
-    `maven-publish`
-    signing
-    alias(libs.plugins.dokka)
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.plugin.serialization)
     alias(libs.plugins.spotless)
-    alias(libs.plugins.dependency.check)
-    alias(libs.plugins.maven.publish)
-    alias(libs.plugins.kotlinx.knit)
     alias(libs.plugins.kover)
+    alias(libs.plugins.kotlinx.knit)
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.maven.publish)
+    alias(libs.plugins.dependency.check)
 }
 
 repositories {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,27 @@
+
+pluginManagement {
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    //
+    // Provides a repository for downloading JVMs
+    //
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
+dependencyResolutionManagement {
+    @Suppress("UnstableApiUsage")
+    repositories {
+        google()
+        mavenCentral()
+        mavenLocal()
+    }
+}
+
 rootProject.name = "eudi-lib-jvm-sdjwt-kt"


### PR DESCRIPTION
This PR removes two gradle plugins that seems redundant
- `signing`
- maven-publish

