### PR TITLE
Pass SD-JWT VC claimset as an extra parameter when checking X5C trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ val sdJwtVcVerification = runBlocking {
             signer.issue(spec).getOrThrow().serialize()
         }
 
-        val verifier = SdJwtVcVerifier.usingX5c { chain -> chain.firstOrNull() == certificate }
+        val verifier = SdJwtVcVerifier.usingX5c { chain, _ -> chain.firstOrNull() == certificate }
         verifier.verify(sdJwt)
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import java.security.cert.X509Certificate
 import java.text.ParseException
 import com.nimbusds.jose.jwk.JWK as NimbusJWK
@@ -41,6 +42,12 @@ fun interface X509CertificateTrust {
 
     companion object {
         val None: X509CertificateTrust = X509CertificateTrust { _, _ -> false }
+
+        fun usingVct(trust: suspend (List<X509Certificate>, String) -> Boolean): X509CertificateTrust =
+            X509CertificateTrust { chain, claimSet ->
+                val vct = checkNotNull(claimSet[SdJwtVcSpec.VCT]) { "missing '${SdJwtVcSpec.VCT}' claim" }
+                trust(chain, vct.jsonPrimitive.content)
+            }
     }
 }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -23,7 +23,6 @@ import io.ktor.client.plugins.cookies.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -48,7 +47,7 @@ class PidDevVerificationTest :
     private fun doTest(unverifiedSdJwtVc: String, enableLogging: Boolean = false) = runTest {
         val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingX5cOrIssuerMetadata(
             httpClientFactory = { createHttpClient(enableLogging = enableLogging) },
-            x509CertificateTrust = { _ -> true },
+            x509CertificateTrust = { _, _ -> true },
         )
 
         val issuedSdJwt = try {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -78,7 +78,7 @@ val sdJwtVcVerification = runBlocking {
             signer.issue(spec).getOrThrow().serialize()
         }
 
-        val verifier = SdJwtVcVerifier.usingX5c { chain -> chain.firstOrNull() == certificate }
+        val verifier = SdJwtVcVerifier.usingX5c { chain, _ -> chain.firstOrNull() == certificate }
         verifier.verify(sdJwt)
     }
 }


### PR DESCRIPTION
`X509CertificateTrust` now accepts the SD-JWT VC claimset as a `JsonObject` as an extra parameter when checking whether an X5C chain is trusted or not.