### PR TITLE
Introduce `FirstNotNullOfOrNull`

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/FirstNotNullOfOrNull.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/FirstNotNullOfOrNull.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt
+
+/**
+ * Suspend function that returns the result of the first suspend function in [functions] that returns a non-null value.
+ */
+class FirstNotNullOfOrNull<A : Any, B : Any>(
+    private val functions: Iterable<suspend (A) -> B?>,
+) : suspend (A) -> B? {
+    override suspend fun invoke(value: A): B? = functions.firstNotNullOfOrNull { it(value) }
+
+    companion object {
+        operator fun <A : Any, B : Any> invoke(
+            first: suspend (A) -> B?,
+            vararg remaining: suspend (A) -> B?,
+        ): FirstNotNullOfOrNull<A, B> = FirstNotNullOfOrNull(listOf(first, *remaining))
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/FunctionExt.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/FunctionExt.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt
+
+/**
+ * Converts [this] to a function from [A] to [C] given a mapping function from [B] to [C].
+ */
+inline fun <A, B, C> ((A) -> B).map(
+    crossinline f: (B) -> C,
+): (A) -> C = {
+    f(this(it))
+}
+
+/**
+ * Converts [this] to a suspending function from [C] to [B] given a mapping function from [A] to [C].
+ */
+inline fun <A, B, C> ((A) -> B).contraMap(
+    crossinline f: (C) -> A,
+): (C) -> B = {
+    this(f(it))
+}
+
+/**
+ * Converts [this] to a suspending function from [A] to [C] given a mapping function from [B] to [C].
+ */
+inline fun <A, B, C> (suspend (A) -> B).map(
+    crossinline f: (B) -> C,
+): suspend (A) -> C = {
+    f(this(it))
+}
+
+/**
+ * Converts [this] to a suspending function from [C] to [B] given a mapping function from [A] to [C].
+ */
+inline fun <A, B, C> (suspend (A) -> B).contraMap(
+    crossinline f: (C) -> A,
+): suspend (C) -> B = {
+    this(f(it))
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/FunctionExt.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/FunctionExt.kt
@@ -25,7 +25,7 @@ inline fun <A, B, C> ((A) -> B).map(
 }
 
 /**
- * Converts [this] to a suspending function from [C] to [B] given a mapping function from [A] to [C].
+ * Converts [this] to a function from [C] to [B] given a mapping function from [A] to [C].
  */
 inline fun <A, B, C> ((A) -> B).contraMap(
     crossinline f: (C) -> A,

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/ResolveTypeMetadata.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/ResolveTypeMetadata.kt
@@ -30,8 +30,10 @@ fun interface LookupTypeMetadata : suspend (Vct) -> Result<SdJwtVcTypeMetadata?>
             lookup: suspend (Vct) -> SdJwtVcTypeMetadata?,
         ): LookupTypeMetadata = LookupTypeMetadata { vct -> runCatching { lookup(vct) } }
 
-        fun firstNotNullOfOrNull(first: LookupTypeMetadata, vararg remaining: LookupTypeMetadata): LookupTypeMetadata =
-            LookupTypeMetadata(FirstNotNullOfOrNull(listOf(first, *remaining).map { f -> f.map { it.getOrNull() } }))
+        fun firstNotNullOfOrNull(
+            first: suspend (Vct) -> Result<SdJwtVcTypeMetadata?>,
+            vararg remaining: suspend (Vct) -> Result<SdJwtVcTypeMetadata?>,
+        ): LookupTypeMetadata = LookupTypeMetadata(FirstNotNullOfOrNull(listOf(first, *remaining).map { f -> f.map { it.getOrNull() } }))
     }
 }
 
@@ -58,8 +60,10 @@ fun interface LookupJsonSchema : suspend (String) -> Result<JsonSchema?> {
             lookup: suspend (String) -> JsonSchema?,
         ): LookupJsonSchema = LookupJsonSchema { runCatching { lookup(it) } }
 
-        fun firstNotNullOfOrNull(first: LookupJsonSchema, vararg remaining: LookupJsonSchema): LookupJsonSchema =
-            LookupJsonSchema(FirstNotNullOfOrNull(listOf(first, *remaining).map { f -> f.map { it.getOrNull() } }))
+        fun firstNotNullOfOrNull(
+            first: suspend (String) -> Result<JsonSchema?>,
+            vararg remaining: suspend (String) -> Result<JsonSchema?>,
+        ): LookupJsonSchema = LookupJsonSchema(FirstNotNullOfOrNull(listOf(first, *remaining).map { f -> f.map { it.getOrNull() } }))
     }
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/ResolveTypeMetadata.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/ResolveTypeMetadata.kt
@@ -15,24 +15,23 @@
  */
 package eu.europa.ec.eudi.sdjwt.vc
 
+import eu.europa.ec.eudi.sdjwt.FirstNotNullOfOrNull
+import eu.europa.ec.eudi.sdjwt.map
 import io.ktor.http.*
 
 /**
  * Lookup the Type Metadata of a VCT.
  */
-fun interface LookupTypeMetadata {
-
-    suspend operator fun invoke(vct: Vct): Result<SdJwtVcTypeMetadata?>
+fun interface LookupTypeMetadata : suspend (Vct) -> Result<SdJwtVcTypeMetadata?> {
 
     companion object {
-        fun firstNotNullOfOrNull(first: LookupTypeMetadata, vararg remaining: LookupTypeMetadata): LookupTypeMetadata {
-            val lookups = listOf(first, *remaining)
-            return LookupTypeMetadata { vct ->
-                runCatching {
-                    lookups.firstNotNullOfOrNull { lookup -> lookup(vct).getOrNull() }
-                }
-            }
-        }
+
+        operator fun invoke(
+            lookup: suspend (Vct) -> SdJwtVcTypeMetadata?,
+        ): LookupTypeMetadata = LookupTypeMetadata { vct -> runCatching { lookup(vct) } }
+
+        fun firstNotNullOfOrNull(first: LookupTypeMetadata, vararg remaining: LookupTypeMetadata): LookupTypeMetadata =
+            LookupTypeMetadata(FirstNotNullOfOrNull(listOf(first, *remaining).map { f -> f.map { it.getOrNull() } }))
     }
 }
 
@@ -52,19 +51,15 @@ class LookupTypeMetadataUsingKtor(
 /**
  * Lookup a [JsonSchema] from a Uri.
  */
-fun interface LookupJsonSchema {
-
-    suspend operator fun invoke(uri: String): Result<JsonSchema?>
+fun interface LookupJsonSchema : suspend (String) -> Result<JsonSchema?> {
 
     companion object {
-        fun firstNotNullOfOrNull(first: LookupJsonSchema, vararg remaining: LookupJsonSchema): LookupJsonSchema {
-            val lookups = listOf(first, *remaining)
-            return LookupJsonSchema { uri ->
-                runCatching {
-                    lookups.firstNotNullOfOrNull { lookup -> lookup(uri).getOrNull() }
-                }
-            }
-        }
+        operator fun invoke(
+            lookup: suspend (String) -> JsonSchema?,
+        ): LookupJsonSchema = LookupJsonSchema { runCatching { lookup(it) } }
+
+        fun firstNotNullOfOrNull(first: LookupJsonSchema, vararg remaining: LookupJsonSchema): LookupJsonSchema =
+            LookupJsonSchema(FirstNotNullOfOrNull(listOf(first, *remaining).map { f -> f.map { it.getOrNull() } }))
     }
 }
 
@@ -92,6 +87,7 @@ data class ResolvedTypeMetadata(
     init {
         SdJwtVcTypeMetadata.ensureValidPaths(claims)
     }
+
     companion object
 }
 


### PR DESCRIPTION
Introduces `FirstNotNullOfOrNull` alongside `map` and `contraMap` operators for `Function1<A,B>`, and `SuspendFunction1<A,B>` and refactors `firstNotNullOfOrNull` functions of `LookupTypeMetadata` and `LookupJsonSchema` to make use of `FirstNotNullOfOrNull`.