### PR TITLE
Refactor SD-JWT Verifier

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOps.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOps.kt
@@ -59,7 +59,8 @@ private val DefaultSdJwtUnverifiedIssuanceFrom: UnverifiedIssuanceFrom<JwtAndCla
         runCatching {
             val (unverifiedJwt, unverifiedDisclosures) = StandardSerialization.parseIssuance(unverifiedSdJwt)
             val (_, jwtClaims, _) = jwtClaims(unverifiedJwt).getOrThrow()
-            val disclosures = verifyDisclosures(jwtClaims, unverifiedDisclosures).getOrThrow()
+            val disclosures = toDisclosures(unverifiedDisclosures)
+            val recreated = UnsignedSdJwt(jwtClaims, disclosures).recreateClaims(null)
             SdJwt(unverifiedJwt to jwtClaims, disclosures)
         }
     }


### PR DESCRIPTION
Incorporates various verification checks in `RecreateClaims` and refactors `SdJwtVerifier` to make use of `RecreateClaims` instead.