### PR TITLE
Properly limit scope of DSL functions. Make inline buildXXX functions.

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/dsl/DisclosableDsl.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/dsl/DisclosableDsl.kt
@@ -78,7 +78,7 @@ class DisclosableArraySpecBuilder<K, A, DObj, DArr>(
     ): Unit = sdArrClaim(buildDisclosableArray(factory, action))
 }
 
-fun <K, A, DObj, DArr> buildDisclosableArray(
+inline fun <K, A, DObj, DArr> buildDisclosableArray(
     factory: DisclosableContainerFactory<K, A, DObj, DArr>,
     builderAction: DisclosableArraySpecBuilder<K, A, DObj, DArr>.() -> Unit,
 ): DArr
@@ -88,7 +88,7 @@ fun <K, A, DObj, DArr> buildDisclosableArray(
     return factory.arr(content.elements)
 }
 
-fun <K, P> buildDisclosableArray(
+inline fun <K, P> buildDisclosableArray(
     builderAction: DisclosableArraySpecBuilder<K, P, DisclosableObject<K, P>, DisclosableArray<K, P>>.() -> Unit,
 ) = buildDisclosableArray(DisclosableContainerFactory.default(), builderAction)
 
@@ -179,7 +179,7 @@ class DisclosableObjectSpecBuilder<K, P, DObj, DArr>(
     }
 }
 
-fun <K, P, DObj, DArr> buildDisclosableObject(
+inline fun <K, P, DObj, DArr> buildDisclosableObject(
     factory: DisclosableContainerFactory<K, P, DObj, DArr>,
     action: DisclosableObjectSpecBuilder<K, P, DObj, DArr>.() -> Unit,
 ): DObj
@@ -188,6 +188,6 @@ fun <K, P, DObj, DArr> buildDisclosableObject(
     return factory.obj(content.elements)
 }
 
-fun <K, P> buildDisclosableObject(
+inline fun <K, P> buildDisclosableObject(
     action: DisclosableObjectSpecBuilder<K, P, DisclosableObject<K, P>, DisclosableArray<K, P>>.() -> Unit,
 ): DisclosableObject<K, P> = buildDisclosableObject(DisclosableContainerFactory.default(), action)

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/dsl/sdjwt/values/SdJwtElement.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/dsl/sdjwt/values/SdJwtElement.kt
@@ -66,7 +66,8 @@ data class SdJwtArray(
  */
 typealias SdJwtElement = DisclosableElement<String, JsonElement>
 
-private fun factory(
+@PublishedApi
+internal fun factory(
     minimumDigests: Int?,
 ) = object : DisclosableContainerFactory<String, JsonElement, SdJwtObject, SdJwtArray> {
 
@@ -86,6 +87,7 @@ private fun factory(
  *
  * @property elements The list of [SdJwtElement]s built by this builder.
  */
+@DisclosableElementDsl
 class SdJwtArrayBuilder(elements: MutableList<SdJwtElement>) {
 
     private val claims = DisclosableArraySpecBuilder(factory = factory(null), elements)
@@ -192,7 +194,7 @@ class SdJwtArrayBuilder(elements: MutableList<SdJwtElement>) {
  * used to define the array's elements.
  * @return An [SdJwtArray] representing the defined array structure.
  */
-fun buildSdJwtArray(
+inline fun buildSdJwtArray(
     minimumDigests: Int? = null,
     builderAction: SdJwtArrayBuilder.() -> Unit,
 ): SdJwtArray {
@@ -344,7 +346,7 @@ class SdJwtObjectBuilder(elements: MutableMap<String, SdJwtElement>) {
  * used to define the object's claims.
  * @return An [SdJwtObject] representing the defined object structure.
  */
-fun buildSdJwtObject(
+inline fun buildSdJwtObject(
     minimumDigests: Int? = null,
     builderAction: SdJwtObjectBuilder.() -> Unit,
 ): SdJwtObject {
@@ -363,7 +365,7 @@ fun buildSdJwtObject(
  * used to define the object's claims.
  * @return An [SdJwtObject] representing the defined object structure.
  */
-fun sdJwt(
+inline fun sdJwt(
     minimumDigests: Int? = null,
     builderAction: SdJwtObjectBuilder.() -> Unit,
 ): SdJwtObject = buildSdJwtObject(minimumDigests, builderAction)


### PR DESCRIPTION
1. Adds missing `@DisclosableElementDsl` to `SdJwtArrayBuilder`. This fixes scope issues for DSL functions.
2. Marks all `buildXXX` functions as inline to avoid overhead. Side-effect: the function `factory(minimumDigests: Int?)` in `SdJwtElement.kt` has been marked as `@PublishedApi internal`