### PR TITLE
Refactor `SdJwtVcVerifierFactory` and enable `SdJwtDefinition` veriifcation for SD-JWT VC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps
 import eu.europa.ec.eudi.sdjwt.RFC7519
 import eu.europa.ec.eudi.sdjwt.SdJwtVcSpec
 import eu.europa.ec.eudi.sdjwt.dsl.values.sdJwt
+import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
@@ -417,6 +418,7 @@ import org.bouncycastle.asn1.x509.GeneralNames
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import java.math.BigInteger
+import java.security.cert.X509Certificate
 import java.util.*
 import javax.security.auth.x500.X500Principal
 import kotlin.time.Duration.Companion.days
@@ -460,7 +462,10 @@ val sdJwtVcVerification = runBlocking {
             signer.issue(spec).getOrThrow().serialize()
         }
 
-        val verifier = SdJwtVcVerifier.usingX5c { chain, _ -> chain.firstOrNull() == certificate }
+        val verifier = SdJwtVcVerifier(
+            IssuerVerificationMethod { chain: List<X509Certificate>, _ -> chain.firstOrNull() == certificate },
+            null,
+        )
         verifier.verify(sdJwt)
     }
 }

--- a/README.md
+++ b/README.md
@@ -418,7 +418,6 @@ import org.bouncycastle.asn1.x509.GeneralNames
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import java.math.BigInteger
-import java.security.cert.X509Certificate
 import java.util.*
 import javax.security.auth.x500.X500Principal
 import kotlin.time.Duration.Companion.days
@@ -463,7 +462,7 @@ val sdJwtVcVerification = runBlocking {
         }
 
         val verifier = SdJwtVcVerifier(
-            IssuerVerificationMethod { chain: List<X509Certificate>, _ -> chain.firstOrNull() == certificate },
+            IssuerVerificationMethod.usingX5c { chain, _ -> chain.firstOrNull() == certificate },
             null,
         )
         verifier.verify(sdJwt)

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOpsJavaAndAndroidExt.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOpsJavaAndAndroidExt.kt
@@ -15,7 +15,7 @@
  */
 package eu.europa.ec.eudi.sdjwt
 
-import eu.europa.ec.eudi.sdjwt.vc.NimbusSdJwtVcFactory
+import eu.europa.ec.eudi.sdjwt.vc.NimbusSdJwtVcVerifierFactory
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerifierFactory
 import eu.europa.ec.eudi.sdjwt.vc.X509CertificateTrust
 import kotlinx.serialization.json.JsonObject
@@ -24,11 +24,15 @@ import com.nimbusds.jose.jwk.JWK as NimbusJWK
 import com.nimbusds.jwt.SignedJWT as NimbusSignedJWT
 
 val DefaultSdJwtOps.SdJwtVcVerifier: SdJwtVcVerifierFactory<JwtAndClaims, NimbusJWK, List<X509Certificate>>
-    get() = NimbusSdJwtVcFactory.transform(
-        convertJwt = ::nimbusToJwtAndClaims,
-        convertJwk = { it },
-        convertX509Chain = { it },
+    get() = NimbusSdJwtVcVerifierFactory.transform(
+        convertFromJwt = ::jwtAndClaimsToNimbus,
+        convertToJwt = ::nimbusToJwtAndClaims,
+        convertFromJwk = { it },
+        convertToX509Chain = { it },
     )
+
+internal fun jwtAndClaimsToNimbus(jwtAndClaims: JwtAndClaims): NimbusSignedJWT =
+    NimbusSignedJWT.parse(jwtAndClaims.first)
 
 internal fun nimbusToJwtAndClaims(signedJWT: NimbusSignedJWT): JwtAndClaims =
     checkNotNull(signedJWT.serialize()) to signedJWT.jwtClaimsSet.jsonObject()

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/NimbusIntegration.kt
@@ -16,7 +16,7 @@
 package eu.europa.ec.eudi.sdjwt
 
 import eu.europa.ec.eudi.sdjwt.dsl.values.SdJwtObjectBuilder
-import eu.europa.ec.eudi.sdjwt.vc.NimbusSdJwtVcFactory
+import eu.europa.ec.eudi.sdjwt.vc.NimbusSdJwtVcVerifierFactory
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerifierFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -290,7 +290,7 @@ object NimbusSdJwtOps :
         }
     }
 
-    val SdJwtVcVerifier: SdJwtVcVerifierFactory<NimbusSignedJWT, NimbusJWK, List<X509Certificate>> = NimbusSdJwtVcFactory
+    val SdJwtVcVerifier: SdJwtVcVerifierFactory<NimbusSignedJWT, NimbusJWK, List<X509Certificate>> = NimbusSdJwtVcVerifierFactory
 }
 
 private val NimbusSerializationOps: SdJwtSerializationOps<NimbusSignedJWT> =

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
@@ -107,16 +107,16 @@ sealed interface IssuerVerificationMethod<out JWT, out JWK, in X509Chain> {
         }
 
     companion object {
-        operator fun invoke(httpClientFactory: KtorHttpClientFactory): UsingIssuerMetadata = UsingIssuerMetadata(httpClientFactory)
-        operator fun <X509Chain> invoke(
+        fun usingIssuerMetadata(httpClientFactory: KtorHttpClientFactory): UsingIssuerMetadata = UsingIssuerMetadata(httpClientFactory)
+        fun <X509Chain> usingX5c(
             x509CertificateTrust: X509CertificateTrust<X509Chain>,
         ): UsingX5c<X509Chain> = UsingX5c(x509CertificateTrust)
-        operator fun <JWK> invoke(didLookup: LookupPublicKeysFromDIDDocument<JWK>): UsingDID<JWK> = UsingDID(didLookup)
-        operator fun <X509Chain> invoke(
+        fun <JWK> usingDID(didLookup: LookupPublicKeysFromDIDDocument<JWK>): UsingDID<JWK> = UsingDID(didLookup)
+        fun <X509Chain> usingX5cOrIssuerMetadata(
             x509CertificateTrust: X509CertificateTrust<X509Chain>,
             httpClientFactory: KtorHttpClientFactory,
         ): UsingX5cOrIssuerMetadata<X509Chain> = UsingX5cOrIssuerMetadata(x509CertificateTrust, httpClientFactory)
-        operator fun <JWT> invoke(jwtSignatureVerifier: JwtSignatureVerifier<JWT>): Custom<JWT> = Custom(jwtSignatureVerifier)
+        fun <JWT> usingCustom(jwtSignatureVerifier: JwtSignatureVerifier<JWT>): Custom<JWT> = Custom(jwtSignatureVerifier)
     }
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
@@ -15,8 +15,9 @@
  */
 package eu.europa.ec.eudi.sdjwt.vc
 
+import eu.europa.ec.eudi.sdjwt.JwtSignatureVerifier
 import eu.europa.ec.eudi.sdjwt.SdJwtVcSpec
-import eu.europa.ec.eudi.sdjwt.SdJwtVcVerifier
+import eu.europa.ec.eudi.sdjwt.map
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -57,53 +58,89 @@ fun interface LookupPublicKeysFromDIDDocument<out JWK> {
         LookupPublicKeysFromDIDDocument { did, didUrl -> lookup(did, didUrl)?.map(convert) }
 }
 
-interface SdJwtVcVerifierFactory<out JWT, in JWK, out X509Chain> {
+/**
+ * How the Issuer of the Issuer-signed JWT of an SD-JWT VC will be verified.
+ */
+sealed interface IssuerVerificationMethod<out JWT, out JWK, in X509Chain> {
 
     /**
-     * Creates a new [SdJwtVcVerifier] with SD-JWT-VC Issuer Metadata resolution enabled.
+     * Using SD-JWT VC Issuer Metadata
      */
-    fun usingIssuerMetadata(httpClientFactory: KtorHttpClientFactory): SdJwtVcVerifier<JWT>
+    data class UsingIssuerMetadata(val httpClientFactory: KtorHttpClientFactory) : IssuerVerificationMethod<Nothing, Nothing, Any?>
 
     /**
-     * Creates a new [SdJwtVcVerifier] with X509 Certificate trust enabled.
+     * Using X509 Certificate trust
      */
-    fun usingX5c(x509CertificateTrust: X509CertificateTrust<X509Chain>): SdJwtVcVerifier<JWT>
+    data class UsingX5c<X509Chain>(
+        val x509CertificateTrust: X509CertificateTrust<X509Chain>,
+    ) : IssuerVerificationMethod<Nothing, Nothing, X509Chain>
 
     /**
-     * Creates a new [SdJwtVcVerifier] with DID resolution enabled.
+     * Using DID resolution
      */
-    fun usingDID(didLookup: LookupPublicKeysFromDIDDocument<JWK>): SdJwtVcVerifier<JWT>
+    data class UsingDID<JWK>(val didLookup: LookupPublicKeysFromDIDDocument<JWK>) : IssuerVerificationMethod<Nothing, JWK, Any?>
 
     /**
-     * Creates a new [SdJwtVcVerifier] with X509 Certificate trust, and SD-JWT-VC Issuer Metadata resolution enabled.
+     * Using X509 Certificate trust or SD-JWT VC Issuer Metadata
      */
-    fun usingX5cOrIssuerMetadata(
-        x509CertificateTrust: X509CertificateTrust<X509Chain>,
-        httpClientFactory: KtorHttpClientFactory,
+    data class UsingX5cOrIssuerMetadata<X509Chain>(
+        val x509CertificateTrust: X509CertificateTrust<X509Chain>,
+        val httpClientFactory: KtorHttpClientFactory,
+    ) : IssuerVerificationMethod<Nothing, Nothing, X509Chain>
+
+    /**
+     * Using a custom [JwtSignatureVerifier]
+     */
+    data class Custom<JWT>(val jwtSignatureVerifier: JwtSignatureVerifier<JWT>) : IssuerVerificationMethod<JWT, Nothing, Any?>
+
+    fun <JWT1, JWK1, X509Chain1> transform(
+        convertToJwt: (JWT) -> JWT1,
+        convertToJwk: (JWK) -> JWK1,
+        convertFromX509Chain: (X509Chain1) -> X509Chain,
+    ): IssuerVerificationMethod<JWT1, JWK1, X509Chain1> =
+        when (this) {
+            is UsingIssuerMetadata -> UsingIssuerMetadata(httpClientFactory)
+            is UsingX5c -> UsingX5c(x509CertificateTrust.contraMap(convertFromX509Chain))
+            is UsingDID -> UsingDID(didLookup.map(convertToJwk))
+            is UsingX5cOrIssuerMetadata -> UsingX5cOrIssuerMetadata(x509CertificateTrust.contraMap(convertFromX509Chain), httpClientFactory)
+            is Custom -> Custom(jwtSignatureVerifier.map(convertToJwt))
+        }
+
+    companion object {
+        operator fun invoke(httpClientFactory: KtorHttpClientFactory): UsingIssuerMetadata = UsingIssuerMetadata(httpClientFactory)
+        operator fun <X509Chain> invoke(
+            x509CertificateTrust: X509CertificateTrust<X509Chain>,
+        ): UsingX5c<X509Chain> = UsingX5c(x509CertificateTrust)
+        operator fun <JWK> invoke(didLookup: LookupPublicKeysFromDIDDocument<JWK>): UsingDID<JWK> = UsingDID(didLookup)
+        operator fun <X509Chain> invoke(
+            x509CertificateTrust: X509CertificateTrust<X509Chain>,
+            httpClientFactory: KtorHttpClientFactory,
+        ): UsingX5cOrIssuerMetadata<X509Chain> = UsingX5cOrIssuerMetadata(x509CertificateTrust, httpClientFactory)
+        operator fun <JWT> invoke(jwtSignatureVerifier: JwtSignatureVerifier<JWT>): Custom<JWT> = Custom(jwtSignatureVerifier)
+    }
+}
+
+interface SdJwtVcVerifierFactory<JWT, in JWK, out X509Chain> {
+
+    operator fun invoke(
+        issuerVerificationMethod: IssuerVerificationMethod<JWT, JWK, X509Chain>,
+        resolveTypeMetadata: ResolveTypeMetadata?,
     ): SdJwtVcVerifier<JWT>
 
     fun <JWT1, JWK1, X509Chain1> transform(
-        convertJwt: (JWT) -> JWT1,
-        convertJwk: (JWK1) -> JWK,
-        convertX509Chain: (X509Chain) -> X509Chain1,
+        convertFromJwt: (JWT1) -> JWT,
+        convertToJwt: (JWT) -> JWT1,
+        convertFromJwk: (JWK1) -> JWK,
+        convertToX509Chain: (X509Chain) -> X509Chain1,
     ): SdJwtVcVerifierFactory<JWT1, JWK1, X509Chain1> =
         object : SdJwtVcVerifierFactory<JWT1, JWK1, X509Chain1> {
-            override fun usingIssuerMetadata(httpClientFactory: KtorHttpClientFactory): SdJwtVcVerifier<JWT1> =
-                this@SdJwtVcVerifierFactory.usingIssuerMetadata(httpClientFactory).map(convertJwt)
-
-            override fun usingX5c(x509CertificateTrust: X509CertificateTrust<X509Chain1>): SdJwtVcVerifier<JWT1> =
-                this@SdJwtVcVerifierFactory.usingX5c(x509CertificateTrust.contraMap(convertX509Chain)).map(convertJwt)
-
-            override fun usingDID(didLookup: LookupPublicKeysFromDIDDocument<JWK1>): SdJwtVcVerifier<JWT1> =
-                this@SdJwtVcVerifierFactory.usingDID(didLookup.map(convertJwk)).map(convertJwt)
-
-            override fun usingX5cOrIssuerMetadata(
-                x509CertificateTrust: X509CertificateTrust<X509Chain1>,
-                httpClientFactory: KtorHttpClientFactory,
+            override fun invoke(
+                issuerVerificationMethod: IssuerVerificationMethod<JWT1, JWK1, X509Chain1>,
+                resolveTypeMetadata: ResolveTypeMetadata?,
             ): SdJwtVcVerifier<JWT1> =
-                this@SdJwtVcVerifierFactory.usingX5cOrIssuerMetadata(
-                    httpClientFactory = httpClientFactory,
-                    x509CertificateTrust = x509CertificateTrust.contraMap(convertX509Chain),
-                ).map(convertJwt)
+                this@SdJwtVcVerifierFactory.invoke(
+                    issuerVerificationMethod.transform(convertFromJwt, convertFromJwk, convertToX509Chain),
+                    resolveTypeMetadata,
+                ).map(convertToJwt)
         }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -56,7 +56,7 @@ class KeyBindingTest {
 
     private val issuer = IssuerActor(genKey("issuer"))
     private val lookup = LookupPublicKeysFromDIDDocument { _, _ -> listOf(issuer.issuerKey.toPublicJWK()) }
-    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod(lookup), null)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod.usingDID(lookup), null)
     private val holder = HolderActor(genKey("holder"), lookup)
 
     /**
@@ -274,7 +274,7 @@ class HolderActor(
     private val holderKey: ECKey,
     lookup: LookupPublicKeysFromDIDDocument<JWK>,
 ) {
-    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod(lookup), null)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod.usingDID(lookup), null)
 
     fun pubKey(): AsymmetricJWK = holderKey.toPublicJWK()
 
@@ -331,7 +331,7 @@ class VerifierActor(
     private val expectedNumberOfDisclosures: Int,
     lookup: LookupPublicKeysFromDIDDocument<JWK>,
 ) {
-    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod(lookup), null)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod.usingDID(lookup), null)
     private lateinit var lastChallenge: JsonObject
     private var presentation: SdJwt<JwtAndClaims>? = null
     fun query(): VerifierQuery = VerifierQuery(

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -28,6 +28,7 @@ import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps.HolderPubKeyInConfirmationClaim
 import eu.europa.ec.eudi.sdjwt.dsl.values.sdJwt
 import eu.europa.ec.eudi.sdjwt.vc.ClaimPath
+import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
 import eu.europa.ec.eudi.sdjwt.vc.LookupPublicKeysFromDIDDocument
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
@@ -55,7 +56,7 @@ class KeyBindingTest {
 
     private val issuer = IssuerActor(genKey("issuer"))
     private val lookup = LookupPublicKeysFromDIDDocument { _, _ -> listOf(issuer.issuerKey.toPublicJWK()) }
-    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingDID(lookup)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod(lookup), null)
     private val holder = HolderActor(genKey("holder"), lookup)
 
     /**
@@ -273,7 +274,7 @@ class HolderActor(
     private val holderKey: ECKey,
     lookup: LookupPublicKeysFromDIDDocument<JWK>,
 ) {
-    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingDID(lookup)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod(lookup), null)
 
     fun pubKey(): AsymmetricJWK = holderKey.toPublicJWK()
 
@@ -330,7 +331,7 @@ class VerifierActor(
     private val expectedNumberOfDisclosures: Int,
     lookup: LookupPublicKeysFromDIDDocument<JWK>,
 ) {
-    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingDID(lookup)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod(lookup), null)
     private lateinit var lastChallenge: JsonObject
     private var presentation: SdJwt<JwtAndClaims>? = null
     fun query(): VerifierQuery = VerifierQuery(

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -47,7 +47,7 @@ class PidDevVerificationTest :
 
     private fun doTest(unverifiedSdJwtVc: String, enableLogging: Boolean = false) = runTest {
         val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
-            IssuerVerificationMethod(
+            IssuerVerificationMethod.usingX5cOrIssuerMetadata(
                 httpClientFactory = { createHttpClient(enableLogging = enableLogging) },
                 x509CertificateTrust = { _, _ -> true },
             ),

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.sdjwt
 
 import com.nimbusds.jwt.SignedJWT
+import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
 import io.ktor.client.*
 import io.ktor.client.engine.java.*
 import io.ktor.client.plugins.contentnegotiation.*
@@ -45,9 +46,12 @@ class PidDevVerificationTest :
     fun testPy() = doTest(pid2, enableLogging = false)
 
     private fun doTest(unverifiedSdJwtVc: String, enableLogging: Boolean = false) = runTest {
-        val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingX5cOrIssuerMetadata(
-            httpClientFactory = { createHttpClient(enableLogging = enableLogging) },
-            x509CertificateTrust = { _, _ -> true },
+        val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
+            IssuerVerificationMethod(
+                httpClientFactory = { createHttpClient(enableLogging = enableLogging) },
+                x509CertificateTrust = { _, _ -> true },
+            ),
+            null,
         )
 
         val issuedSdJwt = try {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -26,6 +26,7 @@ import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps
 import eu.europa.ec.eudi.sdjwt.RFC7519
 import eu.europa.ec.eudi.sdjwt.SdJwtVcSpec
 import eu.europa.ec.eudi.sdjwt.dsl.values.sdJwt
+import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
@@ -37,6 +38,7 @@ import org.bouncycastle.asn1.x509.GeneralNames
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import java.math.BigInteger
+import java.security.cert.X509Certificate
 import java.util.*
 import javax.security.auth.x500.X500Principal
 import kotlin.time.Duration.Companion.days
@@ -78,7 +80,10 @@ val sdJwtVcVerification = runBlocking {
             signer.issue(spec).getOrThrow().serialize()
         }
 
-        val verifier = SdJwtVcVerifier.usingX5c { chain, _ -> chain.firstOrNull() == certificate }
+        val verifier = SdJwtVcVerifier(
+            IssuerVerificationMethod { chain: List<X509Certificate>, _ -> chain.firstOrNull() == certificate },
+            null,
+        )
         verifier.verify(sdJwt)
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -38,7 +38,6 @@ import org.bouncycastle.asn1.x509.GeneralNames
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import java.math.BigInteger
-import java.security.cert.X509Certificate
 import java.util.*
 import javax.security.auth.x500.X500Principal
 import kotlin.time.Duration.Companion.days
@@ -81,7 +80,7 @@ val sdJwtVcVerification = runBlocking {
         }
 
         val verifier = SdJwtVcVerifier(
-            IssuerVerificationMethod { chain: List<X509Certificate>, _ -> chain.firstOrNull() == certificate },
+            IssuerVerificationMethod.usingX5c { chain, _ -> chain.firstOrNull() == certificate },
             null,
         )
         verifier.verify(sdJwt)

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
@@ -151,7 +151,7 @@ class SdJwtVcIssuanceTest {
     private val issuingService = SdJwtVCIssuer(IssuerSampleCfg)
 
     val sdJwtVcVerifier = DefaultSdJwtOps.SdJwtVcVerifier(
-        IssuerVerificationMethod {
+        IssuerVerificationMethod.usingIssuerMetadata {
             val jwksAsJson = JWKSet(issuingService.config.issuerKey.toPublicJWK()).toString()
             val issuerMetadata = SdJwtVcIssuerMetadata(
                 issuer = issuingService.config.issuer.toString(),

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
@@ -150,14 +150,17 @@ class SdJwtVcIssuanceTest {
 
     private val issuingService = SdJwtVCIssuer(IssuerSampleCfg)
 
-    val sdJwtVcVerifier = DefaultSdJwtOps.SdJwtVcVerifier.usingIssuerMetadata {
-        val jwksAsJson = JWKSet(issuingService.config.issuerKey.toPublicJWK()).toString()
-        val issuerMetadata = SdJwtVcIssuerMetadata(
-            issuer = issuingService.config.issuer.toString(),
-            jwks = Json.parseToJsonElement(jwksAsJson).jsonObject,
-        )
-        HttpMock.clientReturning(issuerMetadata)
-    }
+    val sdJwtVcVerifier = DefaultSdJwtOps.SdJwtVcVerifier(
+        IssuerVerificationMethod {
+            val jwksAsJson = JWKSet(issuingService.config.issuerKey.toPublicJWK()).toString()
+            val issuerMetadata = SdJwtVcIssuerMetadata(
+                issuer = issuingService.config.issuer.toString(),
+                jwks = Json.parseToJsonElement(jwksAsJson).jsonObject,
+            )
+            HttpMock.clientReturning(issuerMetadata)
+        },
+        null,
+    )
 
     @Test
     fun `issued SD-JWT must contain JWT claims type, iat, iss, sub`() = runTest {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -136,14 +136,24 @@ class SdJwtVcVerifierTest {
     @Test
     fun `SdJwtVcVerifier should verify an SD-JWT-VC when iss is HTTPS url using kid`() = runTest {
         val unverifiedSdJwt = SampleIssuer.issueUsingKid(kid = SampleIssuer.KEY_ID)
-        val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod { HttpMock.clientReturning(SampleIssuer.issuerMeta) }, null)
+        val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
+            IssuerVerificationMethod.usingIssuerMetadata {
+                HttpMock.clientReturning(SampleIssuer.issuerMeta)
+            },
+            null,
+        )
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
 
     @Test
     fun `SdJwtVcVerifier should verify an SD-JWT-VC when iss is HTTPS url and no kid`() = runTest {
         val unverifiedSdJwt = SampleIssuer.issueUsingKid(kid = null)
-        val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod { HttpMock.clientReturning(SampleIssuer.issuerMeta) }, null)
+        val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
+            IssuerVerificationMethod.usingIssuerMetadata {
+                HttpMock.clientReturning(SampleIssuer.issuerMeta)
+            },
+            null,
+        )
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
 
@@ -151,7 +161,12 @@ class SdJwtVcVerifierTest {
     fun `SdJwtVcVerifier should not verify an SD-JWT-VC when iss is HTTPS url using wrong kid`() = runTest {
         // In case the issuer uses the KID
         val unverifiedSdJwt = SampleIssuer.issueUsingKid("wrong kid")
-        val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod { HttpMock.clientReturning(SampleIssuer.issuerMeta) }, null)
+        val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
+            IssuerVerificationMethod.usingIssuerMetadata {
+                HttpMock.clientReturning(SampleIssuer.issuerMeta)
+            },
+            null,
+        )
         try {
             verifier.verify(unverifiedSdJwt).getOrThrow()
         } catch (exception: SdJwtVerificationException) {
@@ -182,15 +197,14 @@ class SdJwtVcVerifierTest {
             }
 
             val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
-                IssuerVerificationMethod { did: String, _: String? ->
+                IssuerVerificationMethod.usingDID { did, _ ->
                     assertEquals(didJwk, did)
                     listOf(key.toPublicJWK())
                 },
                 null,
             )
 
-            val serialized =
-                with(NimbusSdJwtOps) { sdJwt.serialize() }
+            val serialized = with(NimbusSdJwtOps) { sdJwt.serialize() }
             verifier.verify(serialized).getOrThrow()
         }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -136,14 +136,14 @@ class SdJwtVcVerifierTest {
     @Test
     fun `SdJwtVcVerifier should verify an SD-JWT-VC when iss is HTTPS url using kid`() = runTest {
         val unverifiedSdJwt = SampleIssuer.issueUsingKid(kid = SampleIssuer.KEY_ID)
-        val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingIssuerMetadata { HttpMock.clientReturning(SampleIssuer.issuerMeta) }
+        val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod { HttpMock.clientReturning(SampleIssuer.issuerMeta) }, null)
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
 
     @Test
     fun `SdJwtVcVerifier should verify an SD-JWT-VC when iss is HTTPS url and no kid`() = runTest {
         val unverifiedSdJwt = SampleIssuer.issueUsingKid(kid = null)
-        val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingIssuerMetadata { HttpMock.clientReturning(SampleIssuer.issuerMeta) }
+        val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod { HttpMock.clientReturning(SampleIssuer.issuerMeta) }, null)
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
 
@@ -151,7 +151,7 @@ class SdJwtVcVerifierTest {
     fun `SdJwtVcVerifier should not verify an SD-JWT-VC when iss is HTTPS url using wrong kid`() = runTest {
         // In case the issuer uses the KID
         val unverifiedSdJwt = SampleIssuer.issueUsingKid("wrong kid")
-        val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingIssuerMetadata { HttpMock.clientReturning(SampleIssuer.issuerMeta) }
+        val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod { HttpMock.clientReturning(SampleIssuer.issuerMeta) }, null)
         try {
             verifier.verify(unverifiedSdJwt).getOrThrow()
         } catch (exception: SdJwtVerificationException) {
@@ -181,10 +181,13 @@ class SdJwtVcVerifierTest {
                 signer.issue(spec).getOrThrow()
             }
 
-            val verifier = DefaultSdJwtOps.SdJwtVcVerifier.usingDID { did, _ ->
-                assertEquals(didJwk, did)
-                listOf(key.toPublicJWK())
-            }
+            val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
+                IssuerVerificationMethod { did: String, _: String? ->
+                    assertEquals(didJwk, did)
+                    listOf(key.toPublicJWK())
+                },
+                null,
+            )
 
             val serialized =
                 with(NimbusSdJwtOps) { sdJwt.serialize() }


### PR DESCRIPTION
1. Introduces `IssuerVerificationMethod`, a sealed interface that defined how the Issuer of an SD-JWT VC must be verified
2. Refactors `SdJwtVcVerifierFactory` and introduces a SAM used to construct `SdJwtVcVerifiers`. The SAM accepts an `IssuerVerificationMethod` and an optional `ResolveTypeMetadata` to allow verification of the SD-JWT VC against its Type Metadata
3. Refactors `NimbusSdJwtVcVerifierFactory` to use `IssuerVerificationMethod` and if a `ResolveTypeMetadata` to also verify the SD-JWT VC against its Type Metadata
4. Introduces new error codes in `SdJwtVcVerificationError` that relate to Type Metadata resolution and validation. See `TypeMetadataVerificationError`

Relates to #346