### PR TITLE
Add support for Json Schema validation in `SdJwtVcVerifier`

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ val sdJwtVcVerification = runBlocking {
         val verifier = SdJwtVcVerifier(
             IssuerVerificationMethod.usingX5c { chain, _ -> chain.firstOrNull() == certificate },
             null,
+            null,
         )
         verifier.verify(sdJwt)
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/JsonSchemaValidator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/JsonSchemaValidator.kt
@@ -61,18 +61,18 @@ sealed interface JsonSchemaValidationResult {
 fun interface JsonSchemaValidator {
 
     /**
-     * Validates [payload] against [schema].
+     * Validates [unvalidated] against [schema].
      */
-    suspend fun validate(payload: JsonObject, schema: JsonSchema): JsonSchemaValidationResult
+    suspend fun validate(unvalidated: JsonObject, schema: JsonSchema): JsonSchemaValidationResult
 
     /**
-     * Validates [payload] against the non-empty list of [schemas].
+     * Validates [unvalidated] against the non-empty list of [schemas].
      *
      * @throws IllegalArgumentException if [schemas] is empty
      */
-    suspend fun validate(payload: JsonObject, schemas: List<JsonSchema>): JsonSchemaValidationResult = coroutineScope {
+    suspend fun validate(unvalidated: JsonObject, schemas: List<JsonSchema>): JsonSchemaValidationResult = coroutineScope {
         require(schemas.isNotEmpty()) { "schemas must not be empty" }
-        schemas.map { async { validate(payload, it) } }
+        schemas.map { async { validate(unvalidated, it) } }
             .awaitAll()
             .fold(JsonSchemaValidationResult.Valid, JsonSchemaValidationResult::plus)
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/JsonSchemaValidator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/JsonSchemaValidator.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt.vc
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * A Json Schema violation.
+ */
+data class JsonSchemaViolation(val description: String, val cause: Throwable? = null) {
+    constructor(description: String) : this(description, null)
+
+    init {
+        require(description.isNotBlank()) { "description must not be blank" }
+    }
+}
+
+/**
+ * Json Schema validation result.
+ */
+sealed interface JsonSchemaValidationResult {
+
+    /**
+     * Validation succeeded
+     */
+    data object Valid : JsonSchemaValidationResult
+
+    /**
+     * Validation failed.
+     *
+     * @property errors the violations that were detected
+     */
+    data class Invalid(val errors: List<JsonSchemaViolation>) : JsonSchemaValidationResult {
+        constructor(first: JsonSchemaViolation, vararg rest: JsonSchemaViolation) : this(listOf(first, *rest))
+
+        init {
+            require(errors.isNotEmpty()) { "errors must not be empty" }
+        }
+    }
+}
+
+/**
+ * Validates a Json payload against a Json Schema.
+ */
+fun interface JsonSchemaValidator {
+
+    /**
+     * Validates [payload] against [schema].
+     */
+    suspend fun validate(payload: JsonObject, schema: JsonSchema): JsonSchemaValidationResult
+
+    /**
+     * Validates [payload] against the non-empty list of [schemas].
+     *
+     * @throws IllegalArgumentException if [schemas] is empty
+     */
+    suspend fun validate(payload: JsonObject, schemas: List<JsonSchema>): JsonSchemaValidationResult = coroutineScope {
+        require(schemas.isNotEmpty()) { "schemas must not be empty" }
+        schemas.map { async { validate(payload, it) } }
+            .awaitAll()
+            .fold(JsonSchemaValidationResult.Valid, JsonSchemaValidationResult::plus)
+    }
+}
+
+private operator fun JsonSchemaValidationResult.plus(other: JsonSchemaValidationResult): JsonSchemaValidationResult {
+    val allErrors = buildList {
+        if (this@plus is JsonSchemaValidationResult.Invalid) addAll(errors)
+        if (other is JsonSchemaValidationResult.Invalid) addAll(other.errors)
+    }
+
+    return if (allErrors.isNotEmpty()) JsonSchemaValidationResult.Invalid(allErrors)
+    else JsonSchemaValidationResult.Valid
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
@@ -94,10 +94,10 @@ private class NimbusSdJwtVcVerifier(
     private suspend fun validate(sdJwt: SdJwt<NimbusSignedJWT>) {
         if (null != resolveTypeMetadata) {
             val typeMetadata = resolveTypeMetadata.resolveTypeMetadataOf(sdJwt)
-            val payload = typeMetadata.validate(sdJwt)
+            val recreatedCredential = typeMetadata.validate(sdJwt)
             val jsonSchemas = typeMetadata.schemas
             if (null != jsonSchemaValidator && jsonSchemas.isNotEmpty()) {
-                jsonSchemaValidator.validatePayloadAgainst(payload, jsonSchemas)
+                jsonSchemaValidator.validatePayloadAgainst(recreatedCredential, jsonSchemas)
             }
         }
     }
@@ -277,7 +277,7 @@ private fun ResolvedTypeMetadata.validate(sdJwt: SdJwt<NimbusSignedJWT>): JsonOb
         }
 
     return when (validationResult) {
-        is DefinitionBasedValidationResult.Valid -> validationResult.payload
+        is DefinitionBasedValidationResult.Valid -> validationResult.recreatedCredential
         is DefinitionBasedValidationResult.Invalid -> raise(
             SdJwtVcVerificationError.TypeMetadataVerificationError.TypeMetadataValidationFailure(validationResult.errors),
         )

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
@@ -112,12 +112,7 @@ private class NimbusSdJwtVcVerifier(
         }
 
     private suspend fun JsonSchemaValidator.validatePayloadAgainst(payload: JsonObject, schemas: List<JsonSchema>) {
-        val result = try {
-            validate(payload, schemas)
-        } catch (error: Exception) {
-            raise(SdJwtVcVerificationError.JsonSchemaVerificationError.JsonSchemaValidationError(error))
-        }
-
+        val result = validate(payload, schemas)
         if (result is JsonSchemaValidationResult.Invalid) {
             raise(SdJwtVcVerificationError.JsonSchemaVerificationError.JsonSchemaValidationFailure(result.errors))
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -154,6 +154,26 @@ sealed interface SdJwtVcVerificationError {
             }
         }
     }
+
+    /**
+     * Verification errors regarding Json schema validations.
+     */
+    sealed interface JsonSchemaVerificationError : SdJwtVcVerificationError {
+
+        /**
+         * Json schema validation failed due to an unexpected [error].
+         */
+        data class JsonSchemaValidationError(val error: Throwable) : JsonSchemaVerificationError
+
+        /**
+         * Indicates violations were found when trying to validate an SD-JWT VC against a Json Schema.
+         */
+        data class JsonSchemaValidationFailure(val errors: List<JsonSchemaViolation>) : JsonSchemaVerificationError {
+            init {
+                require(errors.isNotEmpty()) { "errors must not be empty" }
+            }
+        }
+    }
 }
 
 internal fun raise(error: SdJwtVcVerificationError): Nothing = throw SdJwtVerificationException(VerificationError.SdJwtVcError(error))

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -161,11 +161,6 @@ sealed interface SdJwtVcVerificationError {
     sealed interface JsonSchemaVerificationError : SdJwtVcVerificationError {
 
         /**
-         * Json schema validation failed due to an unexpected [error].
-         */
-        data class JsonSchemaValidationError(val error: Throwable) : JsonSchemaVerificationError
-
-        /**
          * Indicates violations were found when trying to validate an SD-JWT VC against a Json Schema.
          */
         data class JsonSchemaValidationFailure(val errors: List<JsonSchemaViolation>) : JsonSchemaVerificationError {

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -163,7 +163,7 @@ sealed interface SdJwtVcVerificationError {
         /**
          * Indicates violations were found when trying to validate an SD-JWT VC against a Json Schema.
          */
-        data class JsonSchemaValidationFailure(val errors: List<JsonSchemaViolation>) : JsonSchemaVerificationError {
+        data class JsonSchemaValidationFailure(val errors: Map<Int, List<JsonSchemaViolation>>) : JsonSchemaVerificationError {
             init {
                 require(errors.isNotEmpty()) { "errors must not be empty" }
             }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
@@ -125,6 +125,7 @@ interface SdJwtVcVerifierFactory<JWT, in JWK, out X509Chain> {
     operator fun invoke(
         issuerVerificationMethod: IssuerVerificationMethod<JWT, JWK, X509Chain>,
         resolveTypeMetadata: ResolveTypeMetadata?,
+        jsonSchemaValidator: JsonSchemaValidator?,
     ): SdJwtVcVerifier<JWT>
 
     fun <JWT1, JWK1, X509Chain1> transform(
@@ -137,10 +138,12 @@ interface SdJwtVcVerifierFactory<JWT, in JWK, out X509Chain> {
             override fun invoke(
                 issuerVerificationMethod: IssuerVerificationMethod<JWT1, JWK1, X509Chain1>,
                 resolveTypeMetadata: ResolveTypeMetadata?,
+                jsonSchemaValidator: JsonSchemaValidator?,
             ): SdJwtVcVerifier<JWT1> =
                 this@SdJwtVcVerifierFactory.invoke(
                     issuerVerificationMethod.transform(convertFromJwt, convertFromJwk, convertToX509Chain),
                     resolveTypeMetadata,
+                    jsonSchemaValidator,
                 ).map(convertToJwt)
         }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -56,7 +56,7 @@ class KeyBindingTest {
 
     private val issuer = IssuerActor(genKey("issuer"))
     private val lookup = LookupPublicKeysFromDIDDocument { _, _ -> listOf(issuer.issuerKey.toPublicJWK()) }
-    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod.usingDID(lookup), null)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod.usingDID(lookup), null, null)
     private val holder = HolderActor(genKey("holder"), lookup)
 
     /**
@@ -274,7 +274,7 @@ class HolderActor(
     private val holderKey: ECKey,
     lookup: LookupPublicKeysFromDIDDocument<JWK>,
 ) {
-    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod.usingDID(lookup), null)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod.usingDID(lookup), null, null)
 
     fun pubKey(): AsymmetricJWK = holderKey.toPublicJWK()
 
@@ -331,7 +331,7 @@ class VerifierActor(
     private val expectedNumberOfDisclosures: Int,
     lookup: LookupPublicKeysFromDIDDocument<JWK>,
 ) {
-    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod.usingDID(lookup), null)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod.usingDID(lookup), null, null)
     private lateinit var lastChallenge: JsonObject
     private var presentation: SdJwt<JwtAndClaims>? = null
     fun query(): VerifierQuery = VerifierQuery(

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -52,6 +52,7 @@ class PidDevVerificationTest :
                 x509CertificateTrust = { _, _ -> true },
             ),
             null,
+            null,
         )
 
         val issuedSdJwt = try {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -82,6 +82,7 @@ val sdJwtVcVerification = runBlocking {
         val verifier = SdJwtVcVerifier(
             IssuerVerificationMethod.usingX5c { chain, _ -> chain.firstOrNull() == certificate },
             null,
+            null,
         )
         verifier.verify(sdJwt)
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
@@ -160,6 +160,7 @@ class SdJwtVcIssuanceTest {
             HttpMock.clientReturning(issuerMetadata)
         },
         null,
+        null,
     )
 
     @Test

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -141,6 +141,7 @@ class SdJwtVcVerifierTest {
                 HttpMock.clientReturning(SampleIssuer.issuerMeta)
             },
             null,
+            null,
         )
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
@@ -152,6 +153,7 @@ class SdJwtVcVerifierTest {
             IssuerVerificationMethod.usingIssuerMetadata {
                 HttpMock.clientReturning(SampleIssuer.issuerMeta)
             },
+            null,
             null,
         )
         verifier.verify(unverifiedSdJwt).getOrThrow()
@@ -165,6 +167,7 @@ class SdJwtVcVerifierTest {
             IssuerVerificationMethod.usingIssuerMetadata {
                 HttpMock.clientReturning(SampleIssuer.issuerMeta)
             },
+            null,
             null,
         )
         try {
@@ -201,6 +204,7 @@ class SdJwtVcVerifierTest {
                     assertEquals(didJwk, did)
                     listOf(key.toPublicJWK())
                 },
+                null,
                 null,
             )
 


### PR DESCRIPTION
1. Introduces `JsonSchemaValidator`. A functional interface that exposes a SAM to validate a Json payload against a Json Schema.
2. Add an optional `JsonSchemaValidator` parameter to `SdJwtVcVerifierFactory`
3. Add support for Json Schema validation in `NimbusSdJwtVcVerifier` when a `JsonSchemaValidator` has been provided
4. Introduces new error codes in `SdJwtVcVerificationError` that relate to Json Schema validation

Relates to #347 