### PR TITLE
Added some helper function for SdJwtDefinition

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/dsl/def/SdJwtDefinition.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/dsl/def/SdJwtDefinition.kt
@@ -124,7 +124,6 @@ fun DisclosableDef<String, AttributeMetadata>.attributeMetadata(): AttributeMeta
         is DisclosableDef.Arr<String, AttributeMetadata> -> {
             check(value is SdJwtArrayDefinition)
             value.metadata
-            value.metadata
         }
 
         is DisclosableDef.Obj<String, AttributeMetadata> -> {

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/dsl/def/SdJwtDefinition.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/dsl/def/SdJwtDefinition.kt
@@ -146,12 +146,10 @@ fun DisclosableDefObject<String, AttributeMetadata>.findElement(
     }
 
     val head = claimPath.head()
-    require(head is ClaimPathElement.Claim) {
-        "the first element of ClaimPath must be a Claim"
-    }
     val tail = claimPath.tail()?.value.orEmpty()
 
-    return findElement(head, tail)
+    return if (head is ClaimPathElement.Claim) findElement(head, tail)
+    else null
 }
 
 private fun DisclosableDefObject<String, AttributeMetadata>.findElement(
@@ -190,9 +188,11 @@ private fun DisclosableDefArray<String, AttributeMetadata>.findElement(
             is DisclosableDef.Obj ->
                 if (headOfTail is ClaimPathElement.Claim) elementDef.value.findElement(headOfTail, tailOfTail)
                 else null
+
             is DisclosableDef.Arr ->
                 if (headOfTail is ClaimPathElement.ArrayElement) elementDef.value.findElement(tailOfTail)
                 else null
+
             is DisclosableDef.Id -> null
         }
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/dsl/def/FindElementTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/dsl/def/FindElementTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt.dsl.def
+
+import eu.europa.ec.eudi.sdjwt.dsl.Disclosable
+import eu.europa.ec.eudi.sdjwt.vc.ClaimPath
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class FindElementTest {
+
+    @Test
+    fun testWithUnknownAttributes() {
+        listOf(
+            ClaimPath.claim("a").claim("b").claim("c"),
+            ClaimPath.claim("address").claim("b").claim("c"),
+        ).forEach {
+            assertNull(PidDefinition.findElement(it))
+        }
+    }
+
+    @Test
+    fun testWithKnownPidAttributes() {
+        fun findElement(path: ClaimPath) = PidDefinition.findElement(path)
+
+        val nationalitiesDef = findElement(ClaimPath.claim("nationalities"))
+        assertIs<Disclosable.AlwaysSelectively<DisclosableDef.Arr<String, AttributeMetadata>>>(nationalitiesDef)
+
+        val addressDef = findElement(ClaimPath.claim("address"))
+        assertIs<Disclosable.AlwaysSelectively<DisclosableDef.Obj<String, AttributeMetadata>>>(addressDef)
+
+        val eighteenDef = findElement(ClaimPath.claim("age_equal_or_over").claim("18"))
+        assertIs<Disclosable.AlwaysSelectively<DisclosableDef.Id<String, AttributeMetadata>>>(eighteenDef)
+    }
+
+    @Test
+    fun testWithKnownPidAttributesDispla() {
+        fun labelOf(path: ClaimPath, lang: String = "en") =
+            PidDefinition.findElement(path)
+                ?.value?.attributeMetadata()
+                ?.display
+                ?.first { it.lang.value == lang }?.label
+
+        listOf(
+            ClaimPath.claim("nationalities"),
+            ClaimPath.claim("address"),
+            ClaimPath.claim("age_equal_or_over").claim("18"),
+        ).forEach {
+            val label = labelOf(it).also { println(it) }
+            assertNotNull(label)
+        }
+    }
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/dsl/def/FindElementTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/dsl/def/FindElementTest.kt
@@ -26,11 +26,8 @@ class FindElementTest {
     fun failsWhenFirstClaimPathElementIsNotClaim() {
         listOf(
             ClaimPath(listOf(ClaimPathElement.AllArrayElements)),
-            ClaimPath(listOf(ClaimPathElement.ArrayElement(0))),
         ).forEach {
-            assertFailsWith(IllegalArgumentException::class) {
-                PidDefinition.findElement(it)
-            }
+            assertNull(PidDefinition.findElement(it))
         }
     }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/dsl/def/FindElementTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/dsl/def/FindElementTest.kt
@@ -17,20 +17,35 @@ package eu.europa.ec.eudi.sdjwt.dsl.def
 
 import eu.europa.ec.eudi.sdjwt.dsl.Disclosable
 import eu.europa.ec.eudi.sdjwt.vc.ClaimPath
-import kotlin.test.Test
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import eu.europa.ec.eudi.sdjwt.vc.ClaimPathElement
+import kotlin.test.*
 
 class FindElementTest {
+
+    @Test
+    fun failsWhenFirstClaimPathElementIsNotClaim() {
+        listOf(
+            ClaimPath(listOf(ClaimPathElement.AllArrayElements)),
+            ClaimPath(listOf(ClaimPathElement.ArrayElement(0))),
+        ).forEach {
+            assertFailsWith(IllegalArgumentException::class) {
+                PidDefinition.findElement(it)
+            }
+        }
+    }
+
+    @Test
+    fun failsWhenArrayElementsAreUsed() {
+        assertFailsWith(IllegalArgumentException::class) {
+            PidDefinition.findElement(ClaimPath.claim("address").arrayElement(0))
+        }
+    }
 
     @Test
     fun testWithUnknownAttributesOrArrayIndexes() {
         listOf(
             ClaimPath.claim("a").claim("b").claim("c"),
             ClaimPath.claim("address").claim("b").claim("c"),
-            ClaimPath.claim("address").arrayElement(0).claim("country"),
-            ClaimPath.claim("nationalities").arrayElement(0),
         ).forEach {
             assertNull(PidDefinition.findElement(it))
         }
@@ -100,10 +115,8 @@ class FindElementTest {
     @Test
     fun testArraysWithUnknownAttributesOrArrayIndexes() {
         listOf(
-            ClaimPath.claim("addresses").arrayElement(0),
-            ClaimPath.claim("addresses").arrayElement(0).claim("country"),
+            ClaimPath.claim("addresses").claim("country").allArrayElements(),
             ClaimPath.claim("addresses").allArrayElements().claim("country").allArrayElements(),
-            ClaimPath.claim("addresses").allArrayElements().arrayElement(0).claim("country").allArrayElements(),
         ).forEach {
             assertNull(AddressDefinition.findElement(it))
         }


### PR DESCRIPTION
The PR adds two convenient methods when working with SD-JWT-VC definitions

**Find element**

```kotlin
fun DisclosableDefObject<String, AttributeMetadata>.findElement(
    claimPath: ClaimPath,
): SdJwtElementDefinition?
```
Function requires that the given `claimPath` doesn't contain wildcard or array index elements

**Attribute metadata of a defintion**

```kotlin
fun DisclosableDef<String, AttributeMetadata>.attributeMetadata(): AttributeMetadata
```

 