### PR TITLE
DefinitionBasedSdJwtObjectBuilder  - SD-JWT-VC templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,17 @@ In the example below, the Issuer decides to issue an SD-JWT as follows:
 - Uses his RSA key pair to sign the SD-JWT
 
 <!--- INCLUDE
-import com.nimbusds.jose.*
-import com.nimbusds.jose.crypto.*
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.jwk.ECKey
 import eu.europa.ec.eudi.sdjwt.*
+import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps
 import eu.europa.ec.eudi.sdjwt.dsl.values.sdJwt
 import kotlinx.coroutines.runBlocking
 -->
 
 ```kotlin
 val issuedSdJwt: String = runBlocking {
-    val issuerKeyPair = loadRsaKey("/examplesIssuerKey.json")
     val sdJwtSpec = sdJwt {
         claim("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
         claim("iss", "https://example.com/issuer")
@@ -90,7 +91,19 @@ val issuedSdJwt: String = runBlocking {
         }
     }
     with(NimbusSdJwtOps) {
-        val issuer = issuer(signer = RSASSASigner(issuerKeyPair), signAlgorithm = JWSAlgorithm.RS256)
+        val issuerKeyPair = ECKey.parse(
+            """
+         {
+          "kty" : "EC",
+          "crv" : "P-256",
+          "x"   : "TCAER19Zvu3OHF4j4W4vfSVoHIP1ILilDls7vCeGemc",
+          "y"   : "ZxjiWWbZMQGHVWKVQ4hbSIirsVfuecCE6t4jT9F2HZQ",
+          "d"   : "5K5SCos8zf9zRemGGUl6yfok-_NiiryNZsvANWMhF-I"
+         }
+            """.trimIndent(),
+        )
+
+        val issuer = issuer(signer = ECDSASigner(issuerKeyPair), signAlgorithm = JWSAlgorithm.ES256)
         issuer.issue(sdJwtSpec).getOrThrow().serialize()
     }
 }

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -60,7 +60,7 @@ val sdJwtSpec = sdJwt {
     claim("iss", "https://example.com/issuer")
     claim("iat", 1516239022)
     claim("exp", 1735689661)
-    
+
     // Selectively disclosed claims (included as disclosure digests)
     sdClaim("given_name", "John")
     sdClaim("family_name", "Doe")
@@ -75,7 +75,7 @@ You can create nested objects with mixed disclosure properties:
 val sdJwtSpec = sdJwt {
     // Regular claims
     claim("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
-    
+
     // Object with selectively disclosed properties
     objClaim("address") {
         sdClaim("street_address", "Schulstr. 12")
@@ -83,7 +83,7 @@ val sdJwtSpec = sdJwt {
         sdClaim("region", "Sachsen-Anhalt")
         sdClaim("country", "DE")
     }
-    
+
     // Selectively disclosed object (the entire object is disclosed as one unit)
     sdObjClaim("credentials") {
         claim("degree", "Bachelor of Science")
@@ -103,7 +103,7 @@ val sdJwtSpec = sdJwt {
         claim("US")
         sdClaim("DE")
     }
-    
+
     // Selectively disclosed array (the entire array is disclosed as one unit)
     sdArrClaim("languages") {
         claim("en")
@@ -121,7 +121,7 @@ To enhance privacy by preventing correlation through the number of disclosures, 
 ```kotlin
 val sdJwtSpec = sdJwt(minimumDigests = 5) {
     // This ensures at least 5 digests in the top-level object
-    
+
     objClaim("address", minimumDigests = 3) {
         // This ensures at least 3 digests in the address object
         sdClaim("street_address", "Schulstr. 12")
@@ -178,18 +178,19 @@ This converts the flat metadata structure into a hierarchical disclosable struct
 
 ### SD-JWT-VC Templating: Transforming Raw Data with Definitions
 
-The library introduces a powerful **templating capability**, enabling the generation of an **`SdJwtObject` directly from raw JSON data**, using an **`SdJwtDefinition` as a blueprint**. This mechanism automates the intricate process of applying selective disclosure rules and structuring claims according to a predefined schema.
+The library provides a powerful **templating capability** that generates an **`SdJwtObject` directly from raw JSON data** using an **`SdJwtDefinition` as a template**. This feature automates the process of applying selective disclosure rules to your credential data according to a predefined schema.
 
-This approach eliminates the need for manual invocation of `sdClaim`, `objClaim`, or `arrClaim` for each individual field. Instead, you supply your raw credential data as a standard `JsonObject`, and the `SdJwtDefinition` automatically determines:
+Key benefits of this approach:
 
-1.  **Claim Inclusion**: Only claims present in both your raw data and the `SdJwtDefinition` are processed.
-2.  **Selective Disclosure Status**: If the `SdJwtDefinition` designates a claim as selectively disclosable, it's automatically converted into an SD-JWT digest. Otherwise, it's included directly in the payload.
-3.  **Correct Nesting**: Nested objects and arrays within your raw data are automatically mapped to their corresponding structured claims in the `SdJwtObject`, adhering to the definition's hierarchy.
-4.  **Automatic `vct` Inclusion**: The `vct` (Verifiable Credential Type) claim, essential for SD-JWT-VCs, is automatically sourced from the `SdJwtDefinition`'s metadata and included as a non-selectively disclosable claim.
+1. **Simplified Code**: No need to manually call `sdClaim`, `objClaim`, or `arrClaim` for each field
+2. **Automatic Processing**: Supply raw credential data as a standard `JsonObject`, and the template handles the rest
+3. **Consistent Rules Application**: The `SdJwtDefinition` determines:
+   - Which claims to include (only processes claims present in both data and definition)
+   - Whether claims should be selectively disclosable (based on the definition)
+   - How to handle nested structures (objects and arrays)
+   - Automatic inclusion of the required `vct` claim from the definition's metadata
 
-This significantly streamlines the credential issuance process, ensuring the generated SD-JWT-VC consistently adheres to its defined type and disclosure policies without requiring repetitive manual configuration.
-
-The core of this functionality resides within the `DefinitionBasedSdJwtObjectBuilder`, which functions as the template engine. For enhanced usability, a top-level helper function, `sdJwtVc`, encapsulates this builder, allowing for swift `SdJwtObject` creation from your raw data. You can also enforce strict adherence, causing the process to fail if type mismatches or other inconsistencies are detected between your raw data and the definition.
+The `DefinitionBasedSdJwtObjectBuilder` class powers this functionality, with the convenient `sdJwtVc` helper function providing a simple interface. You can enable strict validation to ensure your data matches the definition exactly.
 
 Consider the following comparison to illustrate the efficiency of this templating approach:
 
@@ -233,28 +234,28 @@ by allowing the `SdJwtDefinition` to govern the transformation, resulting in cle
 
 ### Validating SD-JWTs Against Definitions
 
-The `DefinitionBasedSdJwtVcValidator` provides a mechanism to validate an SD-JWT 
-(its payload and provided disclosures) against its `SdJwtDefinition`. 
-This ensures the presented credentials conforming to the expected structure and disclosure rules
+The `DefinitionBasedSdJwtVcValidator` provides a mechanism to validate an SD-JWT (its payload and provided disclosures) against its `SdJwtDefinition`. This ensures that presented credentials conform to the expected structure and disclosure rules.
+
+#### Validation Process
+
+When validating an SD-JWT against a definition, the validator checks:
+1. That all required claims are present
+2. That claims are disclosed according to the definition (selectively or not)
+3. That the structure of claims matches the definition
+4. That the credential type (`vct`) matches the one in the definition
+
+#### Possible Validation Errors
 
 The validation process can identify the following types of errors, reported as `DefinitionViolation` instances:
 
-- `DisclosureInconsistencies`: Indicates issues with the disclosures themselves, 
-such as non-unique disclosures or disclosures without matching digests, 
-preventing the successful reconstruction of claims.
-- `UnknownClaim`: Occurs when a claim in the SD-JWT payload or disclosures is not present in the `SdJwtDefinition`.
-- `WrongClaimType`: Reported when a claim's type (e.g., object, array, or primitive) 
-in the presented SD-JWT does not match its type as defined in the SdJwtDefinition.
-- `IncorrectlyDisclosedClaim`: Signifies that a claim's selective disclosure status 
-(always disclosed vs. selectively disclosed) in the SD-JWT contradicts its definition. 
-For instance, a claim defined as "always selectively disclosable" is found directly in the payload, or vice-versa.
-- `MissingRequiredClaim` According to SD-JWT-VC `iss` and `vct` claims are required and must be never selectively disclosable
-- `InvalidVct` Signifies that the credential has a `vct` claim that is not equal to the one found in the type metadata
- 
-```kotlin
-import eu.europa.ec.eudi.sdjwt.dsl.def.DefinitionBasedSdJwtVcValidator
-import eu.europa.ec.eudi.sdjwt.dsl.def.DefinitionBasedValidationResult
+- `DisclosureInconsistencies`: Issues with the disclosures themselves, such as non-unique disclosures or disclosures without matching digests, preventing the successful reconstruction of claims.
+- `UnknownClaim`: A claim in the SD-JWT payload or disclosures is not present in the `SdJwtDefinition`.
+- `WrongClaimType`: A claim's type (e.g., object, array, or primitive) in the presented SD-JWT does not match its type as defined in the SdJwtDefinition.
+- `IncorrectlyDisclosedClaim`: A claim's selective disclosure status (always disclosed vs. selectively disclosed) in the SD-JWT contradicts its definition. For instance, a claim defined as "always selectively disclosable" is found directly in the payload, or vice-versa.
+- `MissingRequiredClaim`: According to SD-JWT-VC, `iss` and `vct` claims are required and must be never selectively disclosable.
+- `InvalidVct`: The credential has a `vct` claim that is not equal to the one found in the type metadata.
 
+```kotlin
 // Assuming you have your sdJwtDefinition, jwtPayload, and disclosures
 val sdJwtDefinition = TODO()
 val validationResult = with(DefinitionBasedSdJwtVcValidator){
@@ -294,7 +295,7 @@ if (displayInfo != null) {
 
 The DSL's metadata support opens up several future possibilities:
 
-1.**Selective Disclosure Policies**: Define policies for what should be selectively disclosed based on metadata attributes.
+1. **Selective Disclosure Policies**: Define policies for what should be selectively disclosed based on metadata attributes.
 
 ```kotlin
 // Define a policy that makes all PII selectively disclosable
@@ -360,7 +361,7 @@ val sdJwtSpec = sdJwt {
 val sdJwtSpec = sdJwt {
     claim("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
     claim("iss", "https://example.com/issuer")
-    
+
     sdObjClaim("personal_info") {
         sdClaim("given_name", "John")
         sdClaim("family_name", "Doe")
@@ -369,7 +370,7 @@ val sdJwtSpec = sdJwt {
             claim("DE")
         }
     }
-    
+
     sdObjClaim("education") {
         sdArrClaim("degrees") {
             objClaim {

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/dsl/values/DefinitionBasedSdJwtObjectBuilder.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/dsl/values/DefinitionBasedSdJwtObjectBuilder.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt.dsl.values
+
+import eu.europa.ec.eudi.sdjwt.SdJwtVcSpec
+import eu.europa.ec.eudi.sdjwt.dsl.Disclosable
+import eu.europa.ec.eudi.sdjwt.dsl.def.DisclosableDef
+import eu.europa.ec.eudi.sdjwt.dsl.def.SdJwtDefinition
+import eu.europa.ec.eudi.sdjwt.dsl.def.SdJwtElementDefinition
+import kotlinx.serialization.json.*
+
+/**
+ * A builder that given a [sdJwtDefinition] can
+ * transform a JSON Object representing the raw data of the credential
+ * into a [SdJwtObject], that can be processed further to produce an SD-JWT-VC.
+ *
+ * Actually, this builder uses the [sdJwtDefinition] as a template
+ */
+class DefinitionBasedSdJwtObjectBuilder(private val sdJwtDefinition: SdJwtDefinition) {
+
+    /**
+     * Builds the [SdJwtObject] that adheres to the [sdJwtDefinition] given the [data]
+     *
+     * @param data The raw data of the credential. It is expected that adheres to the [sdJwtDefinition]
+     * @return the [SdJwtObject] of the SD-JWT-VC credential and a list of warnings
+     */
+    fun build(data: JsonObject): Pair<SdJwtObject, List<String>> {
+        val definitionToUse = sdJwtDefinition.plusSdJwtVcNeverSelectivelyDisclosableClaims()
+        val dataToUse = data - SdJwtVcSpec.VCT
+        val warnings = mutableListOf<String>()
+        val sdJwtObject =
+            buildSdJwtObject {
+                claim(SdJwtVcSpec.VCT, definitionToUse.metadata.vct.value)
+                addAll(definitionToUse.content, dataToUse, warnings)
+            }
+        return sdJwtObject to warnings.toList()
+    }
+
+    private fun SdJwtObjectBuilder.addAll(
+        definitionContent: Map<String, SdJwtElementDefinition>,
+        dataObject: Map<String, JsonElement>,
+        warnings: MutableList<String>,
+    ) {
+        definitionContent.forEach { (claimName, elementDef) ->
+            val dataValue = dataObject[claimName]
+
+            // Determine if the element is present in the data
+            if (dataValue == null || dataValue is JsonNull) {
+                return@forEach
+            }
+
+            val isSd = elementDef is Disclosable.AlwaysSelectively
+
+            when (elementDef.value) {
+                is DisclosableDef.Id -> {
+                    // Primitive claim
+                    if (isSd) sdClaim(claimName, dataValue)
+                    else claim(claimName, dataValue)
+                }
+
+                is DisclosableDef.Obj -> {
+                    // Nested object
+                    if (dataValue !is JsonObject) {
+                        warnings.add("Type mismatch: data is not an object but definition expects one for '$claimName'")
+                        return@forEach
+                    }
+                    val nestedDef = elementDef.value as DisclosableDef.Obj // Cast needed for content
+                    if (isSd) {
+                        sdObjClaim(claimName) { // Pass minDigests if available
+                            addAll(nestedDef.value.content, dataValue, warnings)
+                        }
+                    } else {
+                        objClaim(claimName) { // Pass minDigests if available
+                            addAll(nestedDef.value.content, dataValue, warnings)
+                        }
+                    }
+                }
+
+                is DisclosableDef.Arr -> {
+                    // Nested array
+                    if (dataValue !is JsonArray) {
+                        // Type mismatch: data is not an array but definition expects one
+                        // Handle error
+                        return@forEach
+                    }
+                    val nestedDef = elementDef.value as DisclosableDef.Arr
+                    if (isSd) {
+                        sdArrClaim(claimName) { // Pass minDigests if available
+                            addElements(nestedDef.value.content, dataValue, warnings)
+                        }
+                    } else {
+                        arrClaim(claimName) { // Pass minDigests if available
+                            addElements(nestedDef.value.content, dataValue, warnings)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun SdJwtArrayBuilder.addElements(
+        elementDefinition: SdJwtElementDefinition,
+        dataArray: JsonArray,
+        warnings: MutableList<String>,
+    ) {
+        val isSd = elementDefinition is Disclosable.AlwaysSelectively
+
+        dataArray.forEach { arrayElement ->
+            when (elementDefinition.value) {
+                is DisclosableDef.Id -> {
+                    // Primitive array element
+                    if (isSd) sdClaim(arrayElement)
+                    else claim(arrayElement)
+                }
+
+                is DisclosableDef.Obj -> {
+                    // Nested object within array
+                    if (arrayElement !is JsonObject) {
+                        warnings.add("Type mismatch: data is not an object but definition expects one for '$arrayElement'")
+                        return@forEach
+                    }
+                    val nestedObjDef = elementDefinition.value as DisclosableDef.Obj
+                    if (isSd) {
+                        sdObjClaim {
+                            addAll(nestedObjDef.value.content, arrayElement, warnings)
+                        }
+                    } else {
+                        objClaim {
+                            addAll(nestedObjDef.value.content, arrayElement, warnings)
+                        }
+                    }
+                }
+
+                is DisclosableDef.Arr -> {
+                    // Nested array within array (rare, but possible)
+                    if (arrayElement !is JsonArray) {
+                        warnings.add("Type mismatch: data is not an array but definition expects one for '$arrayElement'")
+                        return@forEach
+                    }
+                    val nestedArrDef = elementDefinition.value as DisclosableDef.Arr
+                    if (isSd) {
+                        sdArrClaim {
+                            addElements(nestedArrDef.value.content, arrayElement, warnings)
+                        }
+                    } else {
+                        arrClaim {
+                            addElements(nestedArrDef.value.content, arrayElement, warnings)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Builds an [SdJwtObject], for a SD-JWT-VC,  using [sdJwtDefinition] as a template applied on the data of the credential
+ *
+ * @param strict if true, the function fails in case where the raw data do not adhere to the given [sdJwtDefinition]
+ * @param action provides the raw data of the credential. There is no need to provide the `vst` claim. It will be
+ * added automatically from [sdJwtDefinition]
+ *
+ * @return the [SdJwtObject] of the SD-JWT-VC credential
+ */
+fun sdJwtVc(
+    sdJwtDefinition: SdJwtDefinition,
+    strict: Boolean = true,
+    action: JsonObjectBuilder.() -> Unit,
+): Result<SdJwtObject> = runCatching {
+    val data = buildJsonObject(action)
+    val builder = DefinitionBasedSdJwtObjectBuilder(sdJwtDefinition)
+    val (sdJwtObject, warnings) = builder.build(data)
+    if (strict && warnings.isNotEmpty()) {
+        error("Errors : " + warnings.joinToString(", "))
+    } else {
+        sdJwtObject
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/dsl/values/SdJwtElement.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/dsl/values/SdJwtElement.kt
@@ -17,8 +17,11 @@ package eu.europa.ec.eudi.sdjwt.dsl.values
 
 import eu.europa.ec.eudi.sdjwt.MinimumDigests
 import eu.europa.ec.eudi.sdjwt.atLeastDigests
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.serializer
 
 /**
  * Represents the structure of an SD-JWT object (a JSON object)
@@ -102,6 +105,23 @@ class SdJwtArrayBuilder(elements: MutableList<SdJwtElement>) {
     fun claim(value: JsonElement): Unit = claims.claim(value)
 
     /**
+     * Adds a regular (non-selectively disclosable) JSON element to the array.
+     * The value will always be revealed.
+     * @param value The to add.
+     * @param serializer The serializer of the value
+     * @param V the type of the value
+     */
+    fun <V>claim(value: V, serializer: KSerializer<V>): Unit = claims.claim(Json.encodeToJsonElement(serializer, value))
+
+    /**
+     * Adds a regular (non-selectively disclosable) JSON element to the array.
+     * The value will always be revealed.
+     * @param value The to add.
+     * @param V the type of the value
+     */
+    inline fun <reified V>claim(value: V): Unit = claim(value, serializer())
+
+    /**
      * Adds a regular (non-selectively disclosable) string value to the array.
      * @param value The [String] to add.
      */
@@ -125,6 +145,23 @@ class SdJwtArrayBuilder(elements: MutableList<SdJwtElement>) {
      * @param value The [JsonElement] to add.
      */
     fun sdClaim(value: JsonElement): Unit = claims.sdClaim(value)
+
+    /**
+     * Adds a selectively disclosable (SD) JSON element to the array.
+     * The value will be hidden by default and can be selectively disclosed.
+     * @param value The value to add.
+     * @param serializer The serializer of the value
+     * @param V the type of the value
+     */
+    fun <V>sdClaim(value: V, serializer: KSerializer<V>): Unit = claims.sdClaim(Json.encodeToJsonElement(serializer, value))
+
+    /**
+     * Adds a selectively disclosable (SD) JSON element to the array.
+     * The value will be hidden by default and can be selectively disclosed.
+     * @param value The value to add.
+     * @param V the type of the value
+     */
+    inline fun <reified V>sdClaim(value: V): Unit = sdClaim(value, serializer())
 
     /**
      * Adds a selectively disclosable (SD) string value to the array.
@@ -213,9 +250,9 @@ inline fun buildSdJwtArray(
  */
 @DisclosableElementDsl
 class SdJwtObjectBuilder(elements: MutableMap<String, SdJwtElement>) {
+
     private val claims = DisclosableObjectSpecBuilder(factory(null), elements)
-    val elements: Map<String, SdJwtElement>
-        get() = claims.elements
+    val elements: Map<String, SdJwtElement> get() = claims.elements
 
     /**
      * Adds a regular (non-selectively disclosable) JSON element claim to the object.
@@ -224,6 +261,24 @@ class SdJwtObjectBuilder(elements: MutableMap<String, SdJwtElement>) {
      * @param value The [JsonElement] value of the claim.
      */
     fun claim(name: String, value: JsonElement): Unit = claims.claim(name, value)
+
+    /**
+     * Adds a regular (non-selectively disclosable) JSON element claim to the object.
+     * The claim's value will always be revealed.
+     * @param name The name of the claim.
+     * @param value The value of the claim.
+     * @param V the type of the value
+     */
+    fun<V> claim(name: String, value: V, serializer: KSerializer<V>): Unit = claim(name, Json.encodeToJsonElement(serializer, value))
+
+    /**
+     * Adds a regular (non-selectively disclosable) JSON element claim to the object.
+     * The claim's value will always be revealed.
+     * @param name The name of the claim.
+     * @param value The value of the claim.
+     * @param V the type of the value
+     */
+    inline fun<reified V> claim(name: String, value: V): Unit = claim(name, value, serializer())
 
     /**
      * Adds a regular (non-selectively disclosable) string claim to the object.
@@ -253,6 +308,25 @@ class SdJwtObjectBuilder(elements: MutableMap<String, SdJwtElement>) {
      * @param value The [JsonElement] value of the claim.
      */
     fun sdClaim(name: String, value: JsonElement): Unit = claims.sdClaim(name, value)
+
+    /**
+     * Adds a selectively disclosable (SD) JSON element claim to the object.
+     * The claim's value will be hidden by default and can be selectively disclosed.
+     * @param name The name of the claim.
+     * @param value The value of the claim.
+     * @param serializer The serializer of the value
+     * @param V the type of the value
+     */
+    fun<V> sdClaim(name: String, value: V, serializer: KSerializer<V>): Unit = sdClaim(name, Json.encodeToJsonElement(serializer, value))
+
+    /**
+     * Adds a selectively disclosable (SD) JSON element claim to the object.
+     * The claim's value will be hidden by default and can be selectively disclosed.
+     * @param name The name of the claim.
+     * @param value The value of the claim.
+     * @param V the type of the value
+     */
+    inline fun<reified V> sdClaim(name: String, value: V): Unit = sdClaim(name, value, serializer())
 
     /**
      * Adds a selectively disclosable (SD) string claim to the object.

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Utils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Utils.kt
@@ -54,6 +54,9 @@ fun SdJwt<SignedJWT>.prettyPrint() {
     prettyPrint { it.jwtClaimsSet.jsonObject() }
 }
 
+fun UnsignedSdJwt.prettyPrint() {
+    SdJwt(payload, disclosures).prettyPrint({ it })
+}
 fun <JWT> SdJwt<JWT>.prettyPrint(f: (JWT) -> JsonObject) {
     println("SD-JWT with ${disclosures.size} disclosures")
     disclosures.forEach { d ->

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/dsl/values/TemplateTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/dsl/values/TemplateTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt.dsl.values
+
+import eu.europa.ec.eudi.sdjwt.*
+import eu.europa.ec.eudi.sdjwt.dsl.def.AddressDefinition
+import eu.europa.ec.eudi.sdjwt.dsl.def.PidDefinition
+import kotlinx.serialization.json.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TemplateTest {
+
+    @Test
+    fun test() {
+        val sdJwtFactory = SdJwtFactory(
+            saltProvider = { "salt" },
+            decoyGen = object : DecoyGen {
+                override fun gen(hashingAlgorithm: HashAlgorithm): DisclosureDigest {
+                    throw UnsupportedOperationException("Decoy generation not supported for this test")
+                }
+
+                override fun gen(hashingAlgorithm: HashAlgorithm, numOfDecoys: Int): Set<DisclosureDigest> =
+                    emptySet()
+            },
+        )
+
+        val spec =
+            sdJwtVc(PidDefinition) {
+                put("given_name", "Foo")
+                put("family_name", "Bar")
+                putJsonArray("nationalities") {
+                    add("GR")
+                }
+                putJsonObject("age_equal_or_over") { put("18", true) }
+                putJsonObject("address") {
+                    put("country", "GR")
+                    put("street_address", "12345 Main Street")
+                }
+            }.getOrThrow()
+
+        val unsigned = sdJwtFactory.createSdJwt(spec).getOrThrow()
+
+        val expectedSpec = sdJwt {
+            claim(SdJwtVcSpec.VCT, PidDefinition.metadata.vct)
+            sdClaim("given_name", "Foo")
+            sdClaim("family_name", "Bar")
+            sdArrClaim("nationalities") {
+                sdClaim("GR")
+            }
+            sdObjClaim("age_equal_or_over") {
+                sdClaim("18", true)
+            }
+            sdObjClaim("address") {
+                sdClaim("country", "GR")
+                sdClaim("street_address", "12345 Main Street")
+            }
+        }
+
+        val expectedUnsigned = sdJwtFactory.createSdJwt(expectedSpec).getOrThrow()
+
+        assertEquals(expectedUnsigned.recreateClaims(null).toSortedMap(), unsigned.recreateClaims(null).toSortedMap())
+    }
+
+    @Test
+    fun useJsonFile() {
+        val addressesJsonStr = """
+            {
+                "addresses": [
+                    { "street_address": "12345 Main Street", "country": "GR" },
+                    { "locality": "Athens", "country": "GR" }
+                ]
+            }
+        """.trimIndent()
+
+        val addresses = Json.parseToJsonElement(addressesJsonStr).jsonObject
+        val spec =
+            with(DefinitionBasedSdJwtObjectBuilder(AddressDefinition)) {
+                val (spec, errors) = build(addresses)
+                errors.forEach { println(it) }
+                assertEquals(0, errors.size)
+                spec
+            }
+        val unsigned = SdJwtFactory.Default.createSdJwt(spec).getOrThrow()
+        assertEquals(7, unsigned.disclosures.size)
+        assertEquals(3, unsigned.payload.size)
+        val recreated = unsigned.recreateClaims(null) - SdJwtVcSpec.VCT
+        assertEquals(addresses.toSortedMap(), recreated.toSortedMap())
+    }
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleIssueSdJw01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleIssueSdJw01.kt
@@ -15,14 +15,15 @@
  */
 package eu.europa.ec.eudi.sdjwt.examples
 
-import com.nimbusds.jose.*
-import com.nimbusds.jose.crypto.*
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.jwk.ECKey
 import eu.europa.ec.eudi.sdjwt.*
+import eu.europa.ec.eudi.sdjwt.NimbusSdJwtOps
 import eu.europa.ec.eudi.sdjwt.dsl.values.sdJwt
 import kotlinx.coroutines.runBlocking
 
 val issuedSdJwt: String = runBlocking {
-    val issuerKeyPair = loadRsaKey("/examplesIssuerKey.json")
     val sdJwtSpec = sdJwt {
         claim("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
         claim("iss", "https://example.com/issuer")
@@ -36,7 +37,19 @@ val issuedSdJwt: String = runBlocking {
         }
     }
     with(NimbusSdJwtOps) {
-        val issuer = issuer(signer = RSASSASigner(issuerKeyPair), signAlgorithm = JWSAlgorithm.RS256)
+        val issuerKeyPair = ECKey.parse(
+            """
+         {
+          "kty" : "EC",
+          "crv" : "P-256",
+          "x"   : "TCAER19Zvu3OHF4j4W4vfSVoHIP1ILilDls7vCeGemc",
+          "y"   : "ZxjiWWbZMQGHVWKVQ4hbSIirsVfuecCE6t4jT9F2HZQ",
+          "d"   : "5K5SCos8zf9zRemGGUl6yfok-_NiiryNZsvANWMhF-I"
+         }
+            """.trimIndent(),
+        )
+
+        val issuer = issuer(signer = ECDSASigner(issuerKeyPair), signAlgorithm = JWSAlgorithm.ES256)
         issuer.issue(sdJwtSpec).getOrThrow().serialize()
     }
 }


### PR DESCRIPTION
The PR introduces a new way of building `SdJwtObject`

Given a `SdJwtDefinition`, for instance from SD-JWT-VC type metadata, and the raw data of the credential, it produces a `SdJwtObject` ready to be processed to produce the JWT payload and the list of dicslosures of the SD-JWT-VC


```kotlin
    sdJwtVc(PidDefinition) {
          put("given_name", "Foo")
          put("family_name", "Bar")
          putJsonArray("nationalities") {
              add("GR")
          }
          putJsonObject("age_equal_or_over") { put("18", true) }
          putJsonObject("address") {
              put("country", "GR")
              put("street_address", "12345 Main Street")
          }
    }
```