### PR TITLE
Rework recreate claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ val claims: JsonObject = runBlocking {
     }
 
     with(NimbusSdJwtOps) {
-        sdJwt.recreateClaims(visitor = null)
+        sdJwt.recreateClaimsAndDisclosuresPerClaim().first
     }
 }
 ```

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOps.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOps.kt
@@ -60,7 +60,7 @@ private val DefaultSdJwtUnverifiedIssuanceFrom: UnverifiedIssuanceFrom<JwtAndCla
             val (unverifiedJwt, unverifiedDisclosures) = StandardSerialization.parseIssuance(unverifiedSdJwt)
             val (_, jwtClaims, _) = jwtClaims(unverifiedJwt).getOrThrow()
             val disclosures = toDisclosures(unverifiedDisclosures)
-            val recreated = UnsignedSdJwt(jwtClaims, disclosures).recreateClaims(null)
+            val (recreated, _) = SdJwtRecreateClaimsOps.recreateClaimsAndDisclosuresPerClaim(jwtClaims, disclosures).getOrThrow()
             SdJwt(unverifiedJwt to jwtClaims, disclosures)
         }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtFactory.kt
@@ -92,7 +92,7 @@ private operator fun Disclosed.plus(that: Disclosed): Disclosed {
     return Folded(this.path, disclosures, mergedResult)
 }
 
-data class UnsignedSdJwt(val payload: JsonObject, val disclosures: List<Disclosure>)
+data class UnsignedSdJwt(val jwtPayload: JsonObject, val disclosures: List<Disclosure>)
 
 /**
  * Factory for creating an unsigned JWT using the enhanced fold API.

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
@@ -440,7 +440,7 @@ private suspend fun <JWT> doVerify(
     val jwtClaims = claimsOf(jwt)
     val hashAlgorithm = jwtClaims.hashAlgorithm()
     val disclosures = toDisclosures(unverifiedDisclosures)
-    val recreated = UnsignedSdJwt(jwtClaims, disclosures).recreateClaims(null)
+    val (_, _) = SdJwtRecreateClaimsOps.recreateClaimsAndDisclosuresPerClaim(jwtClaims, disclosures).getOrThrow()
 
     // Check Key binding
     val expectedDigest = SdJwtDigest.digest(hashAlgorithm, unverifiedSdJwt).getOrThrow()

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/RecreateClaimsTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/RecreateClaimsTest.kt
@@ -40,11 +40,9 @@ class RecreateClaimsTest {
     }
 
     private fun discloseAndRecreate(sdElements: SdJwtObject): JsonObject {
-        val sdJwt = SdJwtFactory().createSdJwt(sdElements).getOrThrow()
-        return with(SdJwtRecreateClaimsOps { claims: JsonObject -> claims }) {
-            sdJwt.recreateClaims(visitor = null).also {
-                println(json.encodeToString(it))
-            }
+        val unSignedSdJwt = SdJwtFactory().createSdJwt(sdElements).getOrThrow()
+        return unSignedSdJwt.recreateClaimsAndDisclosuresPerClaim().getOrThrow().first.also {
+            println(json.encodeToString(it))
         }
     }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJsonElementArrayElementTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJsonElementArrayElementTest.kt
@@ -47,11 +47,11 @@ class SdJsonElementArrayElementTest {
         }
 
         val sdJwt = SdJwtFactory().createSdJwt(sdJwtElements).getOrThrow().also {
-            println(json.encodeToString(it.payload))
+            println(json.encodeToString(it.jwtPayload))
         }
 
         with(SdJwtRecreateClaimsOps { claims: JsonObject -> claims }) {
-            sdJwt.recreateClaims(visitor = null)
+            sdJwt.recreateClaimsAndDisclosuresPerClaim().getOrThrow().first
         }
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SpecExamples.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SpecExamples.kt
@@ -16,7 +16,6 @@
 package eu.europa.ec.eudi.sdjwt
 
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.encodeToString
 import kotlin.test.Test
 
 class SpecExamples {
@@ -130,7 +129,8 @@ class SpecExamples {
 
     private fun SdJwt<JwtAndClaims>.printRecreated() {
         with(DefaultSdJwtOps) {
-            println(json.encodeToString(recreateClaims(visitor = null)))
+            val recreatedClaims = recreateClaimsAndDisclosuresPerClaim().first
+            println(json.encodeToString(recreatedClaims))
         }
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Utils.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/Utils.kt
@@ -55,7 +55,7 @@ fun SdJwt<SignedJWT>.prettyPrint() {
 }
 
 fun UnsignedSdJwt.prettyPrint() {
-    SdJwt(payload, disclosures).prettyPrint({ it })
+    SdJwt(jwtPayload, disclosures).prettyPrint({ it })
 }
 fun <JWT> SdJwt<JWT>.prettyPrint(f: (JWT) -> JsonObject) {
     println("SD-JWT with ${disclosures.size} disclosures")
@@ -101,7 +101,7 @@ internal fun SdJwtObject.assertThat(description: String = "", expectedDisclosure
     println(description)
     val sdJwtFactory = SdJwtFactory.Default
     val sdJwt = assertNotNull(
-        sdJwtFactory.createSdJwt(this).map { SdJwt(it.payload, it.disclosures) }.getOrNull(),
+        sdJwtFactory.createSdJwt(this).map { SdJwt(it.jwtPayload, it.disclosures) }.getOrNull(),
     ).apply { prettyPrint { it } }
     assertEquals(expectedDisclosuresNo, sdJwt.disclosures.size)
     println("=====================================")

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/dsl/values/TemplateTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/dsl/values/TemplateTest.kt
@@ -52,8 +52,6 @@ class TemplateTest {
                 }
             }.getOrThrow()
 
-        val unsigned = sdJwtFactory.createSdJwt(spec).getOrThrow()
-
         val expectedSpec = sdJwt {
             claim(SdJwtVcSpec.VCT, PidDefinition.metadata.vct)
             sdClaim("given_name", "Foo")
@@ -71,8 +69,12 @@ class TemplateTest {
         }
 
         val expectedUnsigned = sdJwtFactory.createSdJwt(expectedSpec).getOrThrow()
+        val expectedRecreated = expectedUnsigned.recreateClaimsAndDisclosuresPerClaim().getOrThrow().first
 
-        assertEquals(expectedUnsigned.recreateClaims(null).toSortedMap(), unsigned.recreateClaims(null).toSortedMap())
+        val unsigned = sdJwtFactory.createSdJwt(spec).getOrThrow()
+        val actualRecreated = unsigned.recreateClaimsAndDisclosuresPerClaim().getOrThrow().first
+
+        assertEquals(expectedRecreated.toSortedMap(), actualRecreated.toSortedMap())
     }
 
     @Test
@@ -96,8 +98,8 @@ class TemplateTest {
             }
         val unsigned = SdJwtFactory.Default.createSdJwt(spec).getOrThrow()
         assertEquals(7, unsigned.disclosures.size)
-        assertEquals(3, unsigned.payload.size)
-        val recreated = unsigned.recreateClaims(null) - SdJwtVcSpec.VCT
+        assertEquals(3, unsigned.jwtPayload.size)
+        val recreated = unsigned.recreateClaimsAndDisclosuresPerClaim().getOrThrow().first - SdJwtVcSpec.VCT
         assertEquals(addresses.toSortedMap(), recreated.toSortedMap())
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleRecreateClaims01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleRecreateClaims01.kt
@@ -44,6 +44,6 @@ val claims: JsonObject = runBlocking {
     }
 
     with(NimbusSdJwtOps) {
-        sdJwt.recreateClaims(visitor = null)
+        sdJwt.recreateClaimsAndDisclosuresPerClaim().first
     }
 }


### PR DESCRIPTION
This PR tries to reduce the public of the library with regards to recreate claims function

So far library was exposing a `ClaimVisitor` interface. This was used to keep a list of `Disclosure` for each claim, while the original claims of an SD-JWT was calculating by traversing its JWT payload and disclosures.

This was an implementation detail, that leaked to the public API.

PR tries to address exactly this problem.

The interface SdJwtRecreateClaimsOps was redefines as follows

```kotlin
fun interface SdJwtRecreateClaimsOps<in JWT> {

    /**
     * Recreates the claims, used to produce the SD-JWT and at the same time calculates [DisclosuresPerClaimPath]
     *
     */
    fun SdJwt<JWT>.recreateClaimsAndDisclosuresPerClaim(): Pair<JsonObject, DisclosuresPerClaimPath>
}
```

    