### PR TITLE
Introduce `TypeMetadataPolicy`

### DIFF
--- a/Module.md
+++ b/Module.md
@@ -15,14 +15,15 @@ Library's SD-JWT DSL leverages the DSL provided by
 
 - [Issuance](#issuance): As an Issuer use the library to issue a SD-JWT
 - [Holder Verification](#holder-verification): As Holder verify a SD-JWT issued by an Issuer
-- [Presentation Verification](#presentation-verification): As a Verifier verify SD-JWT in simple or in Enveloped Format
+- [Holder Presentation](#holder-presentation): As a Holder of a SD-JWT issued by an Issuer, create a presentation for a Verifier
+- [Presentation Verification](#presentation-verification): As a Verifier verify SD-JWT
 - [Recreate initial claims](#recreate-original-claims): Given a SD-JWT recreate the original claims
 
 #### Issuance
 
 To issue a SD-JWT, an `Issuer` should have:
 
-- Decided on how the issued claims will be selectively disclosed (check [DSL examples](#dsl-examples))
+- Decided on how the issued claims will be selectively disclosed
 - Whether to use decoy digests or not
 - An appropriate signing key pair
 - optionally, decided if and how to include the holder's public key in the SD-JWT
@@ -35,129 +36,120 @@ In the example below, the Issuer decides to issue an SD-JWT as follows:
 - Uses his RSA key pair to sign the SD-JWT
 
 ```kotlin
-import com.nimbusds.jose.crypto.RSASigner
-import com.nimbusds.jose.jwk.RSAKey
-import eu.europa.ec.eudi.sdjwt.*
-
-val issuedSdJwt: String = run {
-  val issuerKeyPair = loadRsaKey("/examplesIssuerKey.json")
-  val sdJwtSpec = sdJwt {
-    plain {
-      sub("6c5c0a49-b589-431d-bae7-219122a9ec2c")
-      iss("https://example.com/issuer")
-      iat(1516239022)
-      exp(1735689661)
+val issuedSdJwt: String = runBlocking {
+    val sdJwtSpec = sdJwt {
+        claim("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
+        claim("iss", "https://example.com/issuer")
+        claim("iat", 1516239022)
+        claim("exp", 1735689661)
+        objClaim("address") {
+            sdClaim("street_address", "Schulstr. 12")
+            sdClaim("locality", "Schulpforta")
+            sdClaim("region", "Sachsen-Anhalt")
+            sdClaim("country", "DE")
+        }
     }
-    structured("address") {
-      sd {
-        put("street_address", "Schulstr. 12")
-        put("locality", "Schulpforta")
-        put("region", "Sachsen-Anhalt")
-        put("country", "DE")
-      }
+    with(NimbusSdJwtOps) {
+        val issuer = issuer(signer = ECDSASigner(issuerEcKeyPair), signAlgorithm = JWSAlgorithm.ES256)
+        issuer.issue(sdJwtSpec).getOrThrow().serialize()
     }
-  }
-  val issuer = SdJwtIssuer.nimbus(signer = RSASSASigner(issuerKeyPair), signAlgorithm = JWSAlgorithm.RS256)
-  issuer.issue(sdJwtSpec).getOrThrow().serialize()
+}
 ```
 
-Please check [KeyBindingTest](src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt) for a more advanced
-issuance scenario, including adding to the SD-JWT, holder public key, to leverage key binding.
+> [!TIP]
+> Please check [KeyBindingTest](src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt) for a more advanced
+> issuance scenario, including adding to the SD-JWT, holder public key, to leverage key binding.
 
 #### Holder Verification
-
-In this case, the SD-JWT is expected to be in serialized form.
 
 `Holder` must know:
 
 - the public key of the `Issuer` and the algorithm used by the Issuer to sign the SD-JWT
 
 ```kotlin
-import com.nimbusds.jose.crypto.ECDSAVerifier
-import com.nimbusds.jose.jwk.*
-import eu.europa.ec.eudi.sdjwt.*
-
-val verifiedIssuanceSdJwt: SdJwt.Issuance<JwtAndClaims> = run {
-  val issuerKeyPair = loadRsaKey("/examplesIssuerKey.json")
-  val jwtSignatureVerifier = RSASSAVerifier(issuerKeyPair).asJwtVerifier()
-
-  val unverifiedIssuanceSdJwt = loadSdJwt("/exampleIssuanceSdJwt.txt")
-  SdJwtVerifier.verifyIssuance(
-    jwtSignatureVerifier = jwtSignatureVerifier,
-    unverifiedSdJwt = unverifiedIssuanceSdJwt,
-  ).getOrThrow()
+val verifiedIssuanceSdJwt: SdJwt<SignedJWT> = runBlocking {
+    with(NimbusSdJwtOps) {
+        val jwtSignatureVerifier = RSASSAVerifier(issuerRsaKeyPair).asJwtVerifier()
+        val unverifiedIssuanceSdJwt = loadSdJwt("/exampleIssuanceSdJwt.txt")
+        verify(jwtSignatureVerifier, unverifiedIssuanceSdJwt).getOrThrow()
+    }
 }
 ```
 
+#### Holder Presentation
+
+In this case, a `Holder` of an SD-JWT issued by an `Issuer`, wants to create a presentation for a `Verifier`.
+The `Holder` should know which of the selectively disclosed claims to include in the presentation.
+The selectively disclosed claims to include in the presentation are expressed using Claim Paths as per
+[SD-JWT VC draft 6](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-06.html#name-claim-path).
+
+```kotlin
+val presentationSdJwt: SdJwt<SignedJWT> = runBlocking {
+    with(NimbusSdJwtOps) {
+        val issuedSdJwt = run {
+            val sdJwtSpec = sdJwt {
+                claim("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
+                claim("iss", "https://example.com/issuer")
+                claim("iat", 1516239022)
+                claim("exp", 1735689661)
+                sdObjClaim("address") {
+                    sdClaim("street_address", "Schulstr. 12")
+                    sdClaim("locality", "Schulpforta")
+                    sdClaim("region", "Sachsen-Anhalt")
+                    sdClaim("country", "DE")
+                }
+            }
+            val issuer = issuer(signer = RSASSASigner(issuerRsaKeyPair), signAlgorithm = JWSAlgorithm.RS256)
+            issuer.issue(sdJwtSpec).getOrThrow()
+        }
+
+        val addressPath = ClaimPath.claim("address")
+        val claimsToInclude = setOf(addressPath.claim("region"), addressPath.claim("country"))
+        issuedSdJwt.present(claimsToInclude)!!
+    }
+}
+```
+
+In the above example, the `Holder` has decided to disclose the claims `region` and `country` of the selectively
+disclosed claim `address`.
+
+The resulting presentation will contain 3 disclosures:
+* 1 disclosure for the selectively disclosed claim `address`
+* 1 disclosure for the selectively disclosed claim `region`
+* 1 disclosure for the selectively disclosed claim `country`
+
+This is because to disclose either the claim `region` or the claim `country`, the claim `address` must be
+disclosed as well.
+
 #### Presentation Verification
 
-##### In simple (not enveloped) format
+##### Using compact serialization
 
-In this case, the SD-JWT is expected to be in Combined Presentation format.
 Verifier should know the public key of the Issuer and the algorithm used by the Issuer
 to sign the SD-JWT. Also, if verification includes Key Binding, the Verifier must also
 know how the public key of the Holder was included in the SD-JWT and which algorithm
 the Holder used to sign the `Key Binding JWT`
 
 ```kotlin
-import eu.europa.ec.eudi.sdjwt.*
-import com.nimbusds.jose.jwk.*
-import com.nimbusds.jose.crypto.ECDSAVerifier
-
-val verifiedPresentationSdJwt: SdJwt.Presentation<JwtAndClaims> = run {
-  val issuerKeyPair = loadRsaKey("/examplesIssuerKey.json")
-  val jwtSignatureVerifier = RSASSAVerifier(issuerKeyPair).asJwtVerifier()
-
-  val unverifiedPresentationSdJwt = loadSdJwt("/examplePresentationSdJwt.txt")
-  SdJwtVerifier.verifyPresentation(
-    jwtSignatureVerifier = jwtSignatureVerifier,
-    keyBindingVerifier = KeyBindingVerifier.MustNotBePresent,
-    unverifiedSdJwt = unverifiedPresentationSdJwt,
-  ).getOrThrow()
+val verifiedPresentationSdJwt: SdJwt<SignedJWT> = runBlocking {
+    with(NimbusSdJwtOps) {
+        val jwtSignatureVerifier = RSASSAVerifier(issuerRsaKeyPair).asJwtVerifier()
+        val unverifiedPresentationSdJwt = loadSdJwt("/examplePresentationSdJwt.txt")
+        verify(
+            jwtSignatureVerifier,
+            unverifiedPresentationSdJwt,
+        ).getOrThrow()
+    }
 }
 ```
+
+Library provides various variants of the above method that:
+
+- Preserve the KB-JWT, if present, to the successful outcome of a verification
+- Accept the unverified SD-JWT serialized in JWS JSON
 
 Please check [KeyBindingTest](src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt) for a more advanced
 presentation scenario which includes key binding
-
-##### In enveloped format
-
-In this case, the SD-JWT is expected to be in envelope format.
-Verifier should know
-- the public key of the Issuer and the algorithm used by the Issuer to sign the SD-JWT.
-- the public key and the signing algorithm used by the Holder to sign the envelope JWT, since the envelope acts
-  like a proof of possession (replacing the key binding JWT)
-
-
-```kotlin
-import com.nimbusds.jose.crypto.ECDSAVerifier
-import com.nimbusds.jose.jwk.*
-import eu.europa.ec.eudi.sdjwt.*
-import java.time.Clock
-import java.time.Duration
-
-val verifiedEnvelopedSdJwt: SdJwt.Presentation<JwtAndClaims> = run {
-  val issuerKeyPair = loadRsaKey("/examplesIssuerKey.json")
-  val issuerSignatureVerifier = RSASSAVerifier(issuerKeyPair).asJwtVerifier()
-
-  val holderKeyPair = loadRsaKey("/exampleHolderKey.json")
-  val holderSignatureVerifier = RSASSAVerifier(holderKeyPair).asJwtVerifier()
-    .and { claims ->
-      claims["nonce"] == JsonPrimitive("nonce")
-    }
-
-  val unverifiedEnvelopedSdJwt = loadJwt("/exampleEnvelopedSdJwt.txt")
-
-  SdJwtVerifier.verifyEnvelopedPresentation(
-    sdJwtSignatureVerifier = issuerSignatureVerifier,
-    envelopeJwtVerifier = holderSignatureVerifier,
-    clock = Clock.systemDefaultZone(),
-    iatOffset = 3650.days.toJavaDuration(),
-    expectedAudience = "verifier",
-    unverifiedEnvelopeJwt = unverifiedEnvelopedSdJwt,
-  ).getOrThrow()
-}
-```
 
 #### Recreate original claims
 
@@ -166,26 +158,27 @@ recreated. This includes the claims that are always disclosed (included in the J
 the digests replaced by selectively disclosable claims found in disclosures.
 
 ```kotlin
-val claims: Claims = run {
-  val issuerKeyPair: RSAKey = loadRsaKey("/examplesIssuerKey.json")
-  val sdJwt: SdJwt.Issuance<NimbusSignedJWT> =
-    signedSdJwt(signer = RSASSASigner(issuerKeyPair), signAlgorithm = JWSAlgorithm.RS256) {
-      plain {
-        sub("6c5c0a49-b589-431d-bae7-219122a9ec2c")
-        iss("https://example.com/issuer")
-        iat(1516239022)
-        exp(1735689661)
-      }
-      structured("address") {
-        sd {
-          put("street_address", "Schulstr. 12")
-          put("locality", "Schulpforta")
-          put("region", "Sachsen-Anhalt")
-          put("country", "DE")
+val claims: JsonObject = runBlocking {
+    val sdJwt: SdJwt<SignedJWT> = run {
+        val spec = sdJwt {
+            claim("sub", "6c5c0a49-b589-431d-bae7-219122a9ec2c")
+            claim("iss", "https://example.com/issuer")
+            claim("iat", 1516239022)
+            claim("exp", 1735689661)
+            objClaim("address") {
+                sdClaim("street_address", "Schulstr. 12")
+                sdClaim("locality", "Schulpforta")
+                sdClaim("region", "Sachsen-Anhalt")
+                sdClaim("country", "DE")
+            }
         }
-      }
+        val issuer = NimbusSdJwtOps.issuer(signer = RSASSASigner(issuerRsaKeyPair), signAlgorithm = JWSAlgorithm.RS256)
+        issuer.issue(spec).getOrThrow()
     }
-  sdJwt.recreateClaims { jwt -> jwt.jwtClaimsSet.asClaims() }
+
+    with(NimbusSdJwtOps) {
+        sdJwt.recreateClaimsAndDisclosuresPerClaim().first
+    }
 }
 ```
 
@@ -194,14 +187,14 @@ The claims contents would be
 ```json
 {
   "sub": "6c5c0a49-b589-431d-bae7-219122a9ec2c",
-  "iss": "https://example.com/issuer",
-  "iat": 1516239022,
-  "exp": 1735689661,
   "address": {
     "street_address": "Schulstr. 12",
     "locality": "Schulpforta",
     "region": "Sachsen-Anhalt",
     "country": "DE"
-  }
+  },
+  "iss": "https://example.com/issuer",
+  "exp": 1735689661,
+  "iat": 1516239022
 }
 ```

--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ import eu.europa.ec.eudi.sdjwt.RFC7519
 import eu.europa.ec.eudi.sdjwt.SdJwtVcSpec
 import eu.europa.ec.eudi.sdjwt.dsl.values.sdJwt
 import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
+import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataResolutionPolicy
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 -->
@@ -427,6 +428,7 @@ val sdJwtVcVerification = runBlocking {
             },
             resolveTypeMetadata = null,
             jsonSchemaValidator = null,
+            typeMetadataResolutionPolicy = TypeMetadataResolutionPolicy.Optional,
         )
         verifier.verify(sdJwt)
     }
@@ -466,6 +468,13 @@ val resolver = ResolveTypeMetadata(
 )
 val typeMetadata = resolver(Vct("https://example.com/credentials/sample")).getOrThrow()
 ```
+
+When constructing an `SdJwtVcVerifier`, a Verifier can provide a `ResolveTypeMetadata` instance alongside a `TypeMetadataResolutionPolicy` that describes his policy concerning Type Metadata resolution.
+Currently, the library provides the following policies:
+
+- `TypeMetadataResolutionPolicy.Optional`: Type Metadata resolution is optional. If resolution succeeds, Type Metadata are used for extra validation checks of an SD-JWT VC. If resolution fails, no further checks are performed.
+- `TypeMetadataResolutionPolicy.AlwaysRequired`: Type Metadata resolution is always required. If resolution fails, the SD-JWT VC is rejected.
+- `TypeMetadataResolutionPolicy.RequiredFor`: Applies the policy `TypeMetadataResolutionPolicy.AlwaysRequired` for a set of specified Vcts, and `TypeMetadataResolutionPolicy.Optional` for all everything else.
 
 ### Definition-Based SD-JWT Object Building
 

--- a/README.md
+++ b/README.md
@@ -426,9 +426,7 @@ val sdJwtVcVerification = runBlocking {
             issuerVerificationMethod = IssuerVerificationMethod.usingX5c { chain, _ ->
                 chain.first().base64 == issuerEcKeyPairWithCertificate.x509CertChain.first()
             },
-            resolveTypeMetadata = null,
-            jsonSchemaValidator = null,
-            typeMetadataPolicy = TypeMetadataPolicy.Optional,
+            typeMetadataPolicy = TypeMetadataPolicy.NotUsed,
         )
         verifier.verify(sdJwt)
     }
@@ -469,9 +467,10 @@ val resolver = ResolveTypeMetadata(
 val typeMetadata = resolver(Vct("https://example.com/credentials/sample")).getOrThrow()
 ```
 
-When constructing an `SdJwtVcVerifier`, a Verifier can provide a `ResolveTypeMetadata` instance alongside a `TypeMetadataPolicy` that describes his policy concerning Type Metadata.
+When constructing an `SdJwtVcVerifier`, a Verifier can provide a `TypeMetadataPolicy` that describes his policy concerning Type Metadata.
 Currently, the library provides the following policies:
 
+- `TypeMetadataPolicy.NotUsed`: Type Metadata are not used.
 - `TypeMetadataPolicy.Optional`: Type Metadata are optional. If resolution succeeds, Type Metadata are used for extra validation checks of the SD-JWT VC. If resolution fails, no further checks are performed.
 - `TypeMetadataPolicy.AlwaysRequired`: Type Metadata are always required. If resolution succeeds, Type Metadata are used for extra validation checks of the SD-JWT VC. If resolution fails, the SD-JWT VC is rejected.
 - `TypeMetadataPolicy.RequiredFor`: Applies `TypeMetadataPolicy.AlwaysRequired` for a set of specified Vcts, and `TypeMetadataPolicy.Optional` for everything else.

--- a/README.md
+++ b/README.md
@@ -469,12 +469,12 @@ val resolver = ResolveTypeMetadata(
 val typeMetadata = resolver(Vct("https://example.com/credentials/sample")).getOrThrow()
 ```
 
-When constructing an `SdJwtVcVerifier`, a Verifier can provide a `ResolveTypeMetadata` instance alongside a `TypeMetadataPolicy` that describes his policy concerning Type Metadata resolution.
+When constructing an `SdJwtVcVerifier`, a Verifier can provide a `ResolveTypeMetadata` instance alongside a `TypeMetadataPolicy` that describes his policy concerning Type Metadata.
 Currently, the library provides the following policies:
 
-- `TypeMetadataPolicy.Optional`: Type Metadata resolution is optional. If resolution succeeds, Type Metadata are used for extra validation checks of the SD-JWT VC. If resolution fails, no further checks are performed.
-- `TypeMetadataPolicy.AlwaysRequired`: Type Metadata resolution is always required. If resolution succeeds, Type Metadata are used for extra validation checks of the SD-JWT VC. If resolution fails, the SD-JWT VC is rejected.
-- `TypeMetadataPolicy.RequiredFor`: Applies the policy `TypeMetadataPolicy.AlwaysRequired` for a set of specified Vcts, and `TypeMetadataPolicy.Optional` for everything else.
+- `TypeMetadataPolicy.Optional`: Type Metadata are optional. If resolution succeeds, Type Metadata are used for extra validation checks of the SD-JWT VC. If resolution fails, no further checks are performed.
+- `TypeMetadataPolicy.AlwaysRequired`: Type Metadata are always required. If resolution succeeds, Type Metadata are used for extra validation checks of the SD-JWT VC. If resolution fails, the SD-JWT VC is rejected.
+- `TypeMetadataPolicy.RequiredFor`: Applies `TypeMetadataPolicy.AlwaysRequired` for a set of specified Vcts, and `TypeMetadataPolicy.Optional` for everything else.
 
 ### Definition-Based SD-JWT Object Building
 

--- a/README.md
+++ b/README.md
@@ -472,9 +472,9 @@ val typeMetadata = resolver(Vct("https://example.com/credentials/sample")).getOr
 When constructing an `SdJwtVcVerifier`, a Verifier can provide a `ResolveTypeMetadata` instance alongside a `TypeMetadataResolutionPolicy` that describes his policy concerning Type Metadata resolution.
 Currently, the library provides the following policies:
 
-- `TypeMetadataResolutionPolicy.Optional`: Type Metadata resolution is optional. If resolution succeeds, Type Metadata are used for extra validation checks of an SD-JWT VC. If resolution fails, no further checks are performed.
-- `TypeMetadataResolutionPolicy.AlwaysRequired`: Type Metadata resolution is always required. If resolution fails, the SD-JWT VC is rejected.
-- `TypeMetadataResolutionPolicy.RequiredFor`: Applies the policy `TypeMetadataResolutionPolicy.AlwaysRequired` for a set of specified Vcts, and `TypeMetadataResolutionPolicy.Optional` for all everything else.
+- `TypeMetadataResolutionPolicy.Optional`: Type Metadata resolution is optional. If resolution succeeds, Type Metadata are used for extra validation checks of the SD-JWT VC. If resolution fails, no further checks are performed.
+- `TypeMetadataResolutionPolicy.AlwaysRequired`: Type Metadata resolution is always required. If resolution succeeds, Type Metadata are used for extra validation checks of the SD-JWT VC. If resolution fails, the SD-JWT VC is rejected.
+- `TypeMetadataResolutionPolicy.RequiredFor`: Applies the policy `TypeMetadataResolutionPolicy.AlwaysRequired` for a set of specified Vcts, and `TypeMetadataResolutionPolicy.Optional` for everything else.
 
 ### Definition-Based SD-JWT Object Building
 

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ import eu.europa.ec.eudi.sdjwt.RFC7519
 import eu.europa.ec.eudi.sdjwt.SdJwtVcSpec
 import eu.europa.ec.eudi.sdjwt.dsl.values.sdJwt
 import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
-import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataResolutionPolicy
+import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataPolicy
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 -->
@@ -428,7 +428,7 @@ val sdJwtVcVerification = runBlocking {
             },
             resolveTypeMetadata = null,
             jsonSchemaValidator = null,
-            typeMetadataResolutionPolicy = TypeMetadataResolutionPolicy.Optional,
+            typeMetadataPolicy = TypeMetadataPolicy.Optional,
         )
         verifier.verify(sdJwt)
     }
@@ -469,12 +469,12 @@ val resolver = ResolveTypeMetadata(
 val typeMetadata = resolver(Vct("https://example.com/credentials/sample")).getOrThrow()
 ```
 
-When constructing an `SdJwtVcVerifier`, a Verifier can provide a `ResolveTypeMetadata` instance alongside a `TypeMetadataResolutionPolicy` that describes his policy concerning Type Metadata resolution.
+When constructing an `SdJwtVcVerifier`, a Verifier can provide a `ResolveTypeMetadata` instance alongside a `TypeMetadataPolicy` that describes his policy concerning Type Metadata resolution.
 Currently, the library provides the following policies:
 
-- `TypeMetadataResolutionPolicy.Optional`: Type Metadata resolution is optional. If resolution succeeds, Type Metadata are used for extra validation checks of the SD-JWT VC. If resolution fails, no further checks are performed.
-- `TypeMetadataResolutionPolicy.AlwaysRequired`: Type Metadata resolution is always required. If resolution succeeds, Type Metadata are used for extra validation checks of the SD-JWT VC. If resolution fails, the SD-JWT VC is rejected.
-- `TypeMetadataResolutionPolicy.RequiredFor`: Applies the policy `TypeMetadataResolutionPolicy.AlwaysRequired` for a set of specified Vcts, and `TypeMetadataResolutionPolicy.Optional` for everything else.
+- `TypeMetadataPolicy.Optional`: Type Metadata resolution is optional. If resolution succeeds, Type Metadata are used for extra validation checks of the SD-JWT VC. If resolution fails, no further checks are performed.
+- `TypeMetadataPolicy.AlwaysRequired`: Type Metadata resolution is always required. If resolution succeeds, Type Metadata are used for extra validation checks of the SD-JWT VC. If resolution fails, the SD-JWT VC is rejected.
+- `TypeMetadataPolicy.RequiredFor`: Applies the policy `TypeMetadataPolicy.AlwaysRequired` for a set of specified Vcts, and `TypeMetadataPolicy.Optional` for everything else.
 
 ### Definition-Based SD-JWT Object Building
 

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
@@ -44,14 +44,8 @@ import com.nimbusds.jwt.SignedJWT as NimbusSignedJWT
 internal object NimbusSdJwtVcVerifierFactory : SdJwtVcVerifierFactory<NimbusSignedJWT, NimbusJWK, List<X509Certificate>> {
     override fun invoke(
         issuerVerificationMethod: IssuerVerificationMethod<SignedJWT, JWK, List<X509Certificate>>,
-        resolveTypeMetadata: ResolveTypeMetadata?,
-        jsonSchemaValidator: JsonSchemaValidator?,
         typeMetadataPolicy: TypeMetadataPolicy,
     ): SdJwtVcVerifier<SignedJWT> {
-        if (TypeMetadataPolicy.Optional != typeMetadataPolicy) {
-            requireNotNull(resolveTypeMetadata) { "resolveTypeMetadata is required when typeMetadataResolutionPolicy is not Optional" }
-        }
-
         val jwtSignatureVerifier = when (issuerVerificationMethod) {
             is IssuerVerificationMethod.UsingIssuerMetadata -> sdJwtVcSignatureVerifier(
                 httpClientFactory = issuerVerificationMethod.httpClientFactory,
@@ -65,14 +59,12 @@ internal object NimbusSdJwtVcVerifierFactory : SdJwtVcVerifierFactory<NimbusSign
             is IssuerVerificationMethod.Custom -> issuerVerificationMethod.jwtSignatureVerifier
         }
 
-        return NimbusSdJwtVcVerifier(jwtSignatureVerifier, resolveTypeMetadata, jsonSchemaValidator, typeMetadataPolicy)
+        return NimbusSdJwtVcVerifier(jwtSignatureVerifier, typeMetadataPolicy)
     }
 }
 
 private class NimbusSdJwtVcVerifier(
     private val jwtSignatureVerifier: JwtSignatureVerifier<NimbusSignedJWT>,
-    private val resolveTypeMetadata: ResolveTypeMetadata?,
-    private val jsonSchemaValidator: JsonSchemaValidator?,
     private val typeMetadataPolicy: TypeMetadataPolicy,
 ) : SdJwtVcVerifier<NimbusSignedJWT> {
     private fun keyBindingVerifierForSdJwtVc(challenge: JsonObject?): KeyBindingVerifier.MustBePresentAndValid<NimbusSignedJWT> =
@@ -83,7 +75,7 @@ private class NimbusSdJwtVcVerifier(
     override suspend fun verify(unverifiedSdJwt: String): Result<SdJwt<NimbusSignedJWT>> =
         runCatching {
             val sdJwt = NimbusSdJwtOps.verify(jwtSignatureVerifier, unverifiedSdJwt).getOrThrow()
-            validate(sdJwt)
+            typeMetadataPolicy.validate(sdJwt)
             sdJwt
         }
 
@@ -94,43 +86,9 @@ private class NimbusSdJwtVcVerifier(
         runCatching {
             val keyBindingVerifier = keyBindingVerifierForSdJwtVc(challenge)
             val sdJwtAndKbJwt = NimbusSdJwtOps.verify(jwtSignatureVerifier, keyBindingVerifier, unverifiedSdJwt).getOrThrow()
-            validate(sdJwtAndKbJwt.sdJwt)
+            typeMetadataPolicy.validate(sdJwtAndKbJwt.sdJwt)
             sdJwtAndKbJwt
         }
-
-    private suspend fun validate(sdJwt: SdJwt<NimbusSignedJWT>) {
-        if (null != resolveTypeMetadata) {
-            resolveTypeMetadata.resolveTypeMetadataOf(sdJwt)?.let { typeMetadata ->
-                val recreatedCredential = typeMetadata.validate(sdJwt)
-                val jsonSchemas = typeMetadata.schemas
-                if (null != jsonSchemaValidator && jsonSchemas.isNotEmpty()) {
-                    jsonSchemaValidator.validatePayloadAgainst(recreatedCredential, jsonSchemas)
-                }
-            }
-        }
-    }
-
-    private suspend fun ResolveTypeMetadata.resolveTypeMetadataOf(sdJwt: SdJwt<NimbusSignedJWT>): ResolvedTypeMetadata? =
-        try {
-            val vct = Vct(sdJwt.jwt.jwtClaimsSet.getStringClaim(SdJwtVcSpec.VCT))
-            val maybeTypeMetadata = this(vct)
-            when (typeMetadataPolicy) {
-                TypeMetadataPolicy.Optional -> maybeTypeMetadata.getOrNull()
-                TypeMetadataPolicy.AlwaysRequired -> maybeTypeMetadata.getOrThrow()
-                is TypeMetadataPolicy.RequiredFor ->
-                    if (vct in typeMetadataPolicy.vcts) maybeTypeMetadata.getOrThrow()
-                    else maybeTypeMetadata.getOrNull()
-            }
-        } catch (error: Exception) {
-            raise(SdJwtVcVerificationError.TypeMetadataVerificationError.TypeMetadataResolutionFailure(error))
-        }
-
-    private suspend fun JsonSchemaValidator.validatePayloadAgainst(payload: JsonObject, schemas: List<JsonSchema>) {
-        val result = validate(payload, schemas)
-        if (result is JsonSchemaValidationResult.Invalid) {
-            raise(SdJwtVcVerificationError.JsonSchemaVerificationError.JsonSchemaValidationFailure(result.errors))
-        }
-    }
 }
 
 /**
@@ -273,6 +231,32 @@ internal fun keySource(jwt: NimbusSignedJWT): SdJwtVcIssuerPublicKeySource {
     }
 }
 
+private suspend fun TypeMetadataPolicy.validate(sdJwt: SdJwt<NimbusSignedJWT>) {
+    val typeMetadata = resolveTypeMetadataOf(sdJwt)
+    if (null != typeMetadata) {
+        val recreatedCredential = typeMetadata.validate(sdJwt)
+        val jsonSchemas = typeMetadata.schemas
+        if (jsonSchemas.isNotEmpty()) {
+            jsonSchemaValidator?.validatePayloadAgainst(recreatedCredential, jsonSchemas)
+        }
+    }
+}
+
+private suspend fun TypeMetadataPolicy.resolveTypeMetadataOf(sdJwt: SdJwt<NimbusSignedJWT>): ResolvedTypeMetadata? =
+    try {
+        val vct = Vct(sdJwt.jwt.jwtClaimsSet.getStringClaim(SdJwtVcSpec.VCT))
+        when (this) {
+            TypeMetadataPolicy.NotUsed -> null
+            is TypeMetadataPolicy.Optional -> resolveTypeMetadata(vct).getOrNull()
+            is TypeMetadataPolicy.AlwaysRequired -> resolveTypeMetadata(vct).getOrThrow()
+            is TypeMetadataPolicy.RequiredFor ->
+                if (vct in vcts) resolveTypeMetadata(vct).getOrThrow()
+                else resolveTypeMetadata(vct).getOrNull()
+        }
+    } catch (error: Exception) {
+        raise(SdJwtVcVerificationError.TypeMetadataVerificationError.TypeMetadataResolutionFailure(error))
+    }
+
 private fun ResolvedTypeMetadata.validate(sdJwt: SdJwt<NimbusSignedJWT>): JsonObject {
     val definition = SdJwtDefinition.fromSdJwtVcMetadata(this, true)
     val validationResult =
@@ -285,5 +269,20 @@ private fun ResolvedTypeMetadata.validate(sdJwt: SdJwt<NimbusSignedJWT>): JsonOb
         is DefinitionBasedValidationResult.Invalid -> raise(
             SdJwtVcVerificationError.TypeMetadataVerificationError.TypeMetadataValidationFailure(validationResult.errors),
         )
+    }
+}
+
+private val TypeMetadataPolicy.jsonSchemaValidator: JsonSchemaValidator?
+    get() = when (this) {
+        TypeMetadataPolicy.NotUsed -> null
+        is TypeMetadataPolicy.Optional -> jsonSchemaValidator
+        is TypeMetadataPolicy.AlwaysRequired -> jsonSchemaValidator
+        is TypeMetadataPolicy.RequiredFor -> jsonSchemaValidator
+    }
+
+private suspend fun JsonSchemaValidator.validatePayloadAgainst(payload: JsonObject, schemas: List<JsonSchema>) {
+    val result = validate(payload, schemas)
+    if (result is JsonSchemaValidationResult.Invalid) {
+        raise(SdJwtVcVerificationError.JsonSchemaVerificationError.JsonSchemaValidationFailure(result.errors))
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
@@ -121,27 +121,27 @@ sealed interface IssuerVerificationMethod<out JWT, out JWK, in X509Chain> {
 }
 
 /**
- * Defines a Verifier's policy concerning Type Metadata resolution.
+ * Defines a Verifier's policy concerning Type Metadata.
  */
-sealed interface TypeMetadataResolutionPolicy {
+sealed interface TypeMetadataPolicy {
 
     /**
-     * Type Metadata resolution is not required.
-     * Failure to successfully resolve Type Metadata for any Vct does not result in the rejection of the SD-JWT VC.
+     * Type Metadata are not required.
+     * Failure to successfully resolve Type Metadata for any Vct, does not result in the rejection of the SD-JWT VC.
      */
-    data object Optional : TypeMetadataResolutionPolicy
+    data object Optional : TypeMetadataPolicy
 
     /**
-     * Type Metadata resolution is always required for all Vcts.
-     * Failure to successfully resolve Type Metadata for any Vct results in the rejection of the SD-JWT VC.
+     * Type Metadata are always required for all Vcts.
+     * Failure to successfully resolve Type Metadata for any Vct, results in the rejection of the SD-JWT VC.
      */
-    data object AlwaysRequired : TypeMetadataResolutionPolicy
+    data object AlwaysRequired : TypeMetadataPolicy
 
     /**
-     * Type Metadata resolution is always required for the specified Vcts.
-     * Failure to successfully resolve Type Metadata for any of the specified Vcts results in the rejection of the SD-JWT VC.
+     * Type Metadata are always required for the specified Vcts.
+     * Failure to successfully resolve Type Metadata for any of the specified Vcts, results in the rejection of the SD-JWT VC.
      */
-    data class RequiredFor(val vcts: Set<Vct>) : TypeMetadataResolutionPolicy {
+    data class RequiredFor(val vcts: Set<Vct>) : TypeMetadataPolicy {
         init {
             require(vcts.isNotEmpty()) { "at least one VCT must be specified" }
         }
@@ -154,7 +154,7 @@ interface SdJwtVcVerifierFactory<JWT, in JWK, out X509Chain> {
         issuerVerificationMethod: IssuerVerificationMethod<JWT, JWK, X509Chain>,
         resolveTypeMetadata: ResolveTypeMetadata?,
         jsonSchemaValidator: JsonSchemaValidator?,
-        typeMetadataResolutionPolicy: TypeMetadataResolutionPolicy,
+        typeMetadataPolicy: TypeMetadataPolicy,
     ): SdJwtVcVerifier<JWT>
 
     fun <JWT1, JWK1, X509Chain1> transform(
@@ -168,13 +168,13 @@ interface SdJwtVcVerifierFactory<JWT, in JWK, out X509Chain> {
                 issuerVerificationMethod: IssuerVerificationMethod<JWT1, JWK1, X509Chain1>,
                 resolveTypeMetadata: ResolveTypeMetadata?,
                 jsonSchemaValidator: JsonSchemaValidator?,
-                typeMetadataResolutionPolicy: TypeMetadataResolutionPolicy,
+                typeMetadataPolicy: TypeMetadataPolicy,
             ): SdJwtVcVerifier<JWT1> =
                 this@SdJwtVcVerifierFactory.invoke(
                     issuerVerificationMethod.transform(convertFromJwt, convertFromJwk, convertToX509Chain),
                     resolveTypeMetadata,
                     jsonSchemaValidator,
-                    typeMetadataResolutionPolicy,
+                    typeMetadataPolicy,
                 ).map(convertToJwt)
         }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
@@ -126,22 +126,37 @@ sealed interface IssuerVerificationMethod<out JWT, out JWK, in X509Chain> {
 sealed interface TypeMetadataPolicy {
 
     /**
+     * Type Metadata are not used.
+     */
+    data object NotUsed : TypeMetadataPolicy
+
+    /**
      * Type Metadata are not required.
      * Failure to successfully resolve Type Metadata for any Vct, does not result in the rejection of the SD-JWT VC.
      */
-    data object Optional : TypeMetadataPolicy
+    data class Optional(
+        val resolveTypeMetadata: ResolveTypeMetadata,
+        val jsonSchemaValidator: JsonSchemaValidator?,
+    ) : TypeMetadataPolicy
 
     /**
      * Type Metadata are always required for all Vcts.
      * Failure to successfully resolve Type Metadata for any Vct, results in the rejection of the SD-JWT VC.
      */
-    data object AlwaysRequired : TypeMetadataPolicy
+    data class AlwaysRequired(
+        val resolveTypeMetadata: ResolveTypeMetadata,
+        val jsonSchemaValidator: JsonSchemaValidator?,
+    ) : TypeMetadataPolicy
 
     /**
      * Type Metadata are always required for the specified Vcts.
      * Failure to successfully resolve Type Metadata for any of the specified Vcts, results in the rejection of the SD-JWT VC.
      */
-    data class RequiredFor(val vcts: Set<Vct>) : TypeMetadataPolicy {
+    data class RequiredFor(
+        val vcts: Set<Vct>,
+        val resolveTypeMetadata: ResolveTypeMetadata,
+        val jsonSchemaValidator: JsonSchemaValidator?,
+    ) : TypeMetadataPolicy {
         init {
             require(vcts.isNotEmpty()) { "at least one VCT must be specified" }
         }
@@ -152,8 +167,6 @@ interface SdJwtVcVerifierFactory<JWT, in JWK, out X509Chain> {
 
     operator fun invoke(
         issuerVerificationMethod: IssuerVerificationMethod<JWT, JWK, X509Chain>,
-        resolveTypeMetadata: ResolveTypeMetadata?,
-        jsonSchemaValidator: JsonSchemaValidator?,
         typeMetadataPolicy: TypeMetadataPolicy,
     ): SdJwtVcVerifier<JWT>
 
@@ -166,14 +179,10 @@ interface SdJwtVcVerifierFactory<JWT, in JWK, out X509Chain> {
         object : SdJwtVcVerifierFactory<JWT1, JWK1, X509Chain1> {
             override fun invoke(
                 issuerVerificationMethod: IssuerVerificationMethod<JWT1, JWK1, X509Chain1>,
-                resolveTypeMetadata: ResolveTypeMetadata?,
-                jsonSchemaValidator: JsonSchemaValidator?,
                 typeMetadataPolicy: TypeMetadataPolicy,
             ): SdJwtVcVerifier<JWT1> =
                 this@SdJwtVcVerifierFactory.invoke(
                     issuerVerificationMethod.transform(convertFromJwt, convertFromJwk, convertToX509Chain),
-                    resolveTypeMetadata,
-                    jsonSchemaValidator,
                     typeMetadataPolicy,
                 ).map(convertToJwt)
         }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -59,9 +59,7 @@ class KeyBindingTest {
     private val lookup = LookupPublicKeysFromDIDDocument { _, _ -> listOf(issuer.issuerKey.toPublicJWK()) }
     private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
         IssuerVerificationMethod.usingDID(lookup),
-        null,
-        null,
-        TypeMetadataPolicy.Optional,
+        TypeMetadataPolicy.NotUsed,
     )
     private val holder = HolderActor(genKey("holder"), lookup)
 
@@ -282,9 +280,7 @@ class HolderActor(
 ) {
     private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
         IssuerVerificationMethod.usingDID(lookup),
-        null,
-        null,
-        TypeMetadataPolicy.Optional,
+        TypeMetadataPolicy.NotUsed,
     )
 
     fun pubKey(): AsymmetricJWK = holderKey.toPublicJWK()
@@ -344,9 +340,7 @@ class VerifierActor(
 ) {
     private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
         IssuerVerificationMethod.usingDID(lookup),
-        null,
-        null,
-        TypeMetadataPolicy.Optional,
+        TypeMetadataPolicy.NotUsed,
     )
     private lateinit var lastChallenge: JsonObject
     private var presentation: SdJwt<JwtAndClaims>? = null

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -30,7 +30,7 @@ import eu.europa.ec.eudi.sdjwt.dsl.values.sdJwt
 import eu.europa.ec.eudi.sdjwt.vc.ClaimPath
 import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
 import eu.europa.ec.eudi.sdjwt.vc.LookupPublicKeysFromDIDDocument
-import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataResolutionPolicy
+import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataPolicy
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DatePeriod
@@ -61,7 +61,7 @@ class KeyBindingTest {
         IssuerVerificationMethod.usingDID(lookup),
         null,
         null,
-        TypeMetadataResolutionPolicy.Optional,
+        TypeMetadataPolicy.Optional,
     )
     private val holder = HolderActor(genKey("holder"), lookup)
 
@@ -284,7 +284,7 @@ class HolderActor(
         IssuerVerificationMethod.usingDID(lookup),
         null,
         null,
-        TypeMetadataResolutionPolicy.Optional,
+        TypeMetadataPolicy.Optional,
     )
 
     fun pubKey(): AsymmetricJWK = holderKey.toPublicJWK()
@@ -346,7 +346,7 @@ class VerifierActor(
         IssuerVerificationMethod.usingDID(lookup),
         null,
         null,
-        TypeMetadataResolutionPolicy.Optional,
+        TypeMetadataPolicy.Optional,
     )
     private lateinit var lastChallenge: JsonObject
     private var presentation: SdJwt<JwtAndClaims>? = null

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -30,6 +30,7 @@ import eu.europa.ec.eudi.sdjwt.dsl.values.sdJwt
 import eu.europa.ec.eudi.sdjwt.vc.ClaimPath
 import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
 import eu.europa.ec.eudi.sdjwt.vc.LookupPublicKeysFromDIDDocument
+import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataResolutionPolicy
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DatePeriod
@@ -56,7 +57,12 @@ class KeyBindingTest {
 
     private val issuer = IssuerActor(genKey("issuer"))
     private val lookup = LookupPublicKeysFromDIDDocument { _, _ -> listOf(issuer.issuerKey.toPublicJWK()) }
-    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod.usingDID(lookup), null, null)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
+        IssuerVerificationMethod.usingDID(lookup),
+        null,
+        null,
+        TypeMetadataResolutionPolicy.Optional,
+    )
     private val holder = HolderActor(genKey("holder"), lookup)
 
     /**
@@ -274,7 +280,12 @@ class HolderActor(
     private val holderKey: ECKey,
     lookup: LookupPublicKeysFromDIDDocument<JWK>,
 ) {
-    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod.usingDID(lookup), null, null)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
+        IssuerVerificationMethod.usingDID(lookup),
+        null,
+        null,
+        TypeMetadataResolutionPolicy.Optional,
+    )
 
     fun pubKey(): AsymmetricJWK = holderKey.toPublicJWK()
 
@@ -331,7 +342,12 @@ class VerifierActor(
     private val expectedNumberOfDisclosures: Int,
     lookup: LookupPublicKeysFromDIDDocument<JWK>,
 ) {
-    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(IssuerVerificationMethod.usingDID(lookup), null, null)
+    private val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
+        IssuerVerificationMethod.usingDID(lookup),
+        null,
+        null,
+        TypeMetadataResolutionPolicy.Optional,
+    )
     private lateinit var lastChallenge: JsonObject
     private var presentation: SdJwt<JwtAndClaims>? = null
     fun query(): VerifierQuery = VerifierQuery(

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -52,9 +52,7 @@ class PidDevVerificationTest :
                 httpClientFactory = { createHttpClient(enableLogging = enableLogging) },
                 x509CertificateTrust = { _, _ -> true },
             ),
-            null,
-            null,
-            TypeMetadataPolicy.Optional,
+            TypeMetadataPolicy.NotUsed,
         )
 
         val issuedSdJwt = try {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.sdjwt
 
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
+import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataResolutionPolicy
 import io.ktor.client.*
 import io.ktor.client.engine.java.*
 import io.ktor.client.plugins.contentnegotiation.*
@@ -53,6 +54,7 @@ class PidDevVerificationTest :
             ),
             null,
             null,
+            TypeMetadataResolutionPolicy.Optional,
         )
 
         val issuedSdJwt = try {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -17,7 +17,7 @@ package eu.europa.ec.eudi.sdjwt
 
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
-import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataResolutionPolicy
+import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataPolicy
 import io.ktor.client.*
 import io.ktor.client.engine.java.*
 import io.ktor.client.plugins.contentnegotiation.*
@@ -54,7 +54,7 @@ class PidDevVerificationTest :
             ),
             null,
             null,
-            TypeMetadataResolutionPolicy.Optional,
+            TypeMetadataPolicy.Optional,
         )
 
         val issuedSdJwt = try {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -48,9 +48,7 @@ val sdJwtVcVerification = runBlocking {
             issuerVerificationMethod = IssuerVerificationMethod.usingX5c { chain, _ ->
                 chain.first().base64 == issuerEcKeyPairWithCertificate.x509CertChain.first()
             },
-            resolveTypeMetadata = null,
-            jsonSchemaValidator = null,
-            typeMetadataPolicy = TypeMetadataPolicy.Optional,
+            typeMetadataPolicy = TypeMetadataPolicy.NotUsed,
         )
         verifier.verify(sdJwt)
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -23,6 +23,7 @@ import eu.europa.ec.eudi.sdjwt.RFC7519
 import eu.europa.ec.eudi.sdjwt.SdJwtVcSpec
 import eu.europa.ec.eudi.sdjwt.dsl.values.sdJwt
 import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
+import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataResolutionPolicy
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 
@@ -49,6 +50,7 @@ val sdJwtVcVerification = runBlocking {
             },
             resolveTypeMetadata = null,
             jsonSchemaValidator = null,
+            typeMetadataResolutionPolicy = TypeMetadataResolutionPolicy.Optional,
         )
         verifier.verify(sdJwt)
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -23,7 +23,7 @@ import eu.europa.ec.eudi.sdjwt.RFC7519
 import eu.europa.ec.eudi.sdjwt.SdJwtVcSpec
 import eu.europa.ec.eudi.sdjwt.dsl.values.sdJwt
 import eu.europa.ec.eudi.sdjwt.vc.IssuerVerificationMethod
-import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataResolutionPolicy
+import eu.europa.ec.eudi.sdjwt.vc.TypeMetadataPolicy
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 
@@ -50,7 +50,7 @@ val sdJwtVcVerification = runBlocking {
             },
             resolveTypeMetadata = null,
             jsonSchemaValidator = null,
-            typeMetadataResolutionPolicy = TypeMetadataResolutionPolicy.Optional,
+            typeMetadataPolicy = TypeMetadataPolicy.Optional,
         )
         verifier.verify(sdJwt)
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
@@ -161,7 +161,7 @@ class SdJwtVcIssuanceTest {
         },
         null,
         null,
-        TypeMetadataResolutionPolicy.Optional,
+        TypeMetadataPolicy.Optional,
     )
 
     @Test

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
@@ -159,9 +159,7 @@ class SdJwtVcIssuanceTest {
             )
             HttpMock.clientReturning(issuerMetadata)
         },
-        null,
-        null,
-        TypeMetadataPolicy.Optional,
+        TypeMetadataPolicy.NotUsed,
     )
 
     @Test

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
@@ -161,6 +161,7 @@ class SdJwtVcIssuanceTest {
         },
         null,
         null,
+        TypeMetadataResolutionPolicy.Optional,
     )
 
     @Test

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
@@ -71,7 +71,7 @@ class SdJwtVcVerifierIntegrationTest {
         jsonSchemaValidator = { unvalidated, schema ->
             JsonSchemaConverter.convert(schema).validate(unvalidated)
         },
-        TypeMetadataResolutionPolicy.AlwaysRequired,
+        TypeMetadataPolicy.AlwaysRequired,
     )
 
     private suspend fun issue(builder: SdJwtObjectBuilder.() -> Unit): String = issuer.issue(sdJwt { builder() }).getOrThrow().serialize()

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
@@ -55,23 +55,24 @@ class SdJwtVcVerifierIntegrationTest {
     private val issuer = NimbusSdJwtOps.issuer(signer = ECDSASigner(issuerKey), signAlgorithm = JWSAlgorithm.ES256)
     private val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
         issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
-        resolveTypeMetadata = ResolveTypeMetadata(
-            lookupTypeMetadata = {
-                assertEquals("urn:eudi:pid:1", it.value)
-                withContext(Dispatchers.IO) {
-                    runCatching {
-                        Json.decodeFromString<SdJwtVcTypeMetadata>(loadResource("/pid_arf_v18.json"))
+        TypeMetadataPolicy.AlwaysRequired(
+            resolveTypeMetadata = ResolveTypeMetadata(
+                lookupTypeMetadata = {
+                    assertEquals("urn:eudi:pid:1", it.value)
+                    withContext(Dispatchers.IO) {
+                        runCatching {
+                            Json.decodeFromString<SdJwtVcTypeMetadata>(loadResource("/pid_arf_v18.json"))
+                        }
                     }
-                }
-            },
-            lookupJsonSchema = {
-                fail("LookupJsonSchema should not have been invoked. Schema URI: $it")
+                },
+                lookupJsonSchema = {
+                    fail("LookupJsonSchema should not have been invoked. Schema URI: $it")
+                },
+            ),
+            jsonSchemaValidator = { unvalidated, schema ->
+                JsonSchemaConverter.convert(schema).validate(unvalidated)
             },
         ),
-        jsonSchemaValidator = { unvalidated, schema ->
-            JsonSchemaConverter.convert(schema).validate(unvalidated)
-        },
-        TypeMetadataPolicy.AlwaysRequired,
     )
 
     private suspend fun issue(builder: SdJwtObjectBuilder.() -> Unit): String = issuer.issue(sdJwt { builder() }).getOrThrow().serialize()

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
@@ -71,6 +71,7 @@ class SdJwtVcVerifierIntegrationTest {
         jsonSchemaValidator = { unvalidated, schema ->
             JsonSchemaConverter.convert(schema).validate(unvalidated)
         },
+        TypeMetadataResolutionPolicy.AlwaysRequired,
     )
 
     private suspend fun issue(builder: SdJwtObjectBuilder.() -> Unit): String = issuer.issue(sdJwt { builder() }).getOrThrow().serialize()

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -140,9 +140,7 @@ class SdJwtVcVerifierTest {
             IssuerVerificationMethod.usingIssuerMetadata {
                 HttpMock.clientReturning(SampleIssuer.issuerMeta)
             },
-            null,
-            null,
-            TypeMetadataPolicy.Optional,
+            TypeMetadataPolicy.NotUsed,
         )
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
@@ -154,9 +152,7 @@ class SdJwtVcVerifierTest {
             IssuerVerificationMethod.usingIssuerMetadata {
                 HttpMock.clientReturning(SampleIssuer.issuerMeta)
             },
-            null,
-            null,
-            TypeMetadataPolicy.Optional,
+            TypeMetadataPolicy.NotUsed,
         )
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
@@ -169,9 +165,7 @@ class SdJwtVcVerifierTest {
             IssuerVerificationMethod.usingIssuerMetadata {
                 HttpMock.clientReturning(SampleIssuer.issuerMeta)
             },
-            null,
-            null,
-            TypeMetadataPolicy.Optional,
+            TypeMetadataPolicy.NotUsed,
         )
         try {
             verifier.verify(unverifiedSdJwt).getOrThrow()
@@ -207,9 +201,7 @@ class SdJwtVcVerifierTest {
                     assertEquals(didJwk, did)
                     listOf(key.toPublicJWK())
                 },
-                null,
-                null,
-                TypeMetadataPolicy.Optional,
+                TypeMetadataPolicy.NotUsed,
             )
 
             val serialized = with(NimbusSdJwtOps) { sdJwt.serialize() }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -142,7 +142,7 @@ class SdJwtVcVerifierTest {
             },
             null,
             null,
-            TypeMetadataResolutionPolicy.Optional,
+            TypeMetadataPolicy.Optional,
         )
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
@@ -156,7 +156,7 @@ class SdJwtVcVerifierTest {
             },
             null,
             null,
-            TypeMetadataResolutionPolicy.Optional,
+            TypeMetadataPolicy.Optional,
         )
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
@@ -171,7 +171,7 @@ class SdJwtVcVerifierTest {
             },
             null,
             null,
-            TypeMetadataResolutionPolicy.Optional,
+            TypeMetadataPolicy.Optional,
         )
         try {
             verifier.verify(unverifiedSdJwt).getOrThrow()
@@ -209,7 +209,7 @@ class SdJwtVcVerifierTest {
                 },
                 null,
                 null,
-                TypeMetadataResolutionPolicy.Optional,
+                TypeMetadataPolicy.Optional,
             )
 
             val serialized = with(NimbusSdJwtOps) { sdJwt.serialize() }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -142,6 +142,7 @@ class SdJwtVcVerifierTest {
             },
             null,
             null,
+            TypeMetadataResolutionPolicy.Optional,
         )
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
@@ -155,6 +156,7 @@ class SdJwtVcVerifierTest {
             },
             null,
             null,
+            TypeMetadataResolutionPolicy.Optional,
         )
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
@@ -169,6 +171,7 @@ class SdJwtVcVerifierTest {
             },
             null,
             null,
+            TypeMetadataResolutionPolicy.Optional,
         )
         try {
             verifier.verify(unverifiedSdJwt).getOrThrow()
@@ -206,6 +209,7 @@ class SdJwtVcVerifierTest {
                 },
                 null,
                 null,
+                TypeMetadataResolutionPolicy.Optional,
             )
 
             val serialized = with(NimbusSdJwtOps) { sdJwt.serialize() }


### PR DESCRIPTION
Currently when Type Metadata resolution is enabled, a Verifier has no way of defining a policy regarding Type Metadata. 

This PR introduces `TypeMetadataPolicy` as a means to rectify the above.
When constructing an `SdJwtVcVerifier`, a Verifier must now also defined a policy regarding Type Metadata.

This PR introduces the following policies:
- `TypeMetadataPolicy.NotUsed`: Type Metadata are not used.
- `TypeMetadataPolicy.Optional`: Type Metadata are optional. In case of resolution success, extra validation are performed against an SD-JWT VC using the resolved Type Metadata. In case of resolution failure, these extra checks are skipped.
- `TypeMetadataPolicy.AlwaysRequired`: Type Metadata are always required. In case of resolution success, extra validation are performed against an SD-JWT VC using the resolved Type Metadata. In case of resolution failure, the SD-JWT VC is rejected.
-  `TypeMetadataPolicy.RequiredFor`: Applies `TypeMetadataPolicy.AlwaysRequired` for a set of specified Vcts, and  `TypeMetadataPolicy.Optional` for everything else.