### PR TITLE
Fix Type Metadata resoultion failure when 'schema_uri#integrity' is present

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/ResolveTypeMetadata.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/ResolveTypeMetadata.kt
@@ -135,7 +135,7 @@ interface ResolveTypeMetadata {
                     val schema = current.schemaUri?.let { schemaUri ->
                         lookupJsonSchema(schemaUri).getOrThrow() ?: error("unable to lookup JsonSchema for $schemaUri")
                     } ?: current.schema
-                    current.copy(schema = schema, schemaUri = null)
+                    current.copy(schema = schema, schemaUri = null, schemaUriIntegrity = null)
                 }
                 val updatedAccumulator = accumulator + current
                 val parent = current.extends?.let { Vct(it) }


### PR DESCRIPTION
During Type Metadata resolution if a JsonSchema is looked up by URI and SRI (sub resource integrity) is present, resolution fails with:
```
unable to resolve sd-jwt vc type metadata, `schema_uri#integrity` must not be provided, if `schema_uri` is not present
```

This invariant is enforced in https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-sdjwt-kt/blob/main/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/TypeMetadata.kt#L80

This PR updates the resolution logic to set `schemaUriIntegrity` to `null` after having successfully looked up a JsonSchema by URI, to fix this issue.