### PR TITLE
Remove deprecated functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ val sdJwtVcVerification = runBlocking {
             }
 
             val signer = issuer(signer = ECDSASigner(issuerEcKeyPairWithCertificate), signAlgorithm = JWSAlgorithm.ES512) {
-                type(JOSEObjectType("vc+sd-jwt"))
+                type(JOSEObjectType(SdJwtVcSpec.MEDIA_SUBTYPE_DC_SD_JWT))
                 x509CertChain(issuerEcKeyPairWithCertificate.x509CertChain)
             }
             signer.issue(spec).getOrThrow().serialize()

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifier.kt
@@ -16,7 +16,6 @@
 package eu.europa.ec.eudi.sdjwt
 
 import eu.europa.ec.eudi.sdjwt.KeyBindingError.*
-import eu.europa.ec.eudi.sdjwt.KeyBindingVerifier.Companion.mustBePresent
 import eu.europa.ec.eudi.sdjwt.KeyBindingVerifier.MustBePresentAndValid
 import eu.europa.ec.eudi.sdjwt.KeyBindingVerifier.MustNotBePresent
 import eu.europa.ec.eudi.sdjwt.VerificationError.*

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Specs.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Specs.kt
@@ -106,13 +106,6 @@ object SdJwtVcSpec {
     const val WELL_KNOWN_SUFFIX_JWT_VC_ISSUER: String = "jwt-vc-issuer"
     const val WELL_KNOWN_JWT_VC_ISSUER: String = "/.well-known/$WELL_KNOWN_SUFFIX_JWT_VC_ISSUER"
 
-    @Deprecated(
-        message = "Removed from SD-JWT-VC",
-        replaceWith = ReplaceWith("SdJwtVcSpec.MEDIA_SUBTYPE_DC_SD_JWT"),
-        level = DeprecationLevel.WARNING,
-    )
-    const val MEDIA_SUBTYPE_VC_SD_JWT: String = "vc+sd-jwt"
-
     //
     // Media types
     //

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
@@ -24,7 +24,7 @@ import eu.europa.ec.eudi.sdjwt.dsl.def.SdJwtDefinition
 import eu.europa.ec.eudi.sdjwt.dsl.def.fromSdJwtVcMetadata
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcIssuerPublicKeySource.*
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerificationError.IssuerKeyVerificationError.*
-import io.ktor.client.HttpClient
+import io.ktor.client.*
 import io.ktor.http.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -103,7 +103,7 @@ private class NimbusSdJwtVcVerifier(
  *  if it is trusted & it contains a SAN URI equal to `iss`
  * - If `iss` claim is a DID the key will be extracted by resolving it.
  *
- *  In addition, the verifier will ensure that `typ` claim is equal to vc+sd-jwt
+ *  In addition, the verifier will ensure that `typ` claim is equal to dc+sd-jwt
  *
  * @param httpClient an http client, used while interacting with issuer
  * @param trust a function that accepts a chain of certificates (contents of `x5c` claim) and

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcJwtProcessor.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcJwtProcessor.kt
@@ -34,14 +34,10 @@ internal class SdJwtVcJwtProcessor<C : NimbusSecurityContext>(
 
     companion object {
         /**
-         * Accepts both the [SdJwtVcSpec.MEDIA_SUBTYPE_DC_SD_JWT]
-         * and the deprecated [SdJwtVcSpec.MEDIA_SUBTYPE_VC_SD_JWT]
+         * Accepts [SdJwtVcSpec.MEDIA_SUBTYPE_DC_SD_JWT].
          */
         private fun <C : NimbusSecurityContext> typeVerifier(): NimbusJOSEObjectTypeVerifier<C> =
-            NimbusDefaultJOSEObjectTypeVerifier(
-                NimbusJOSEObjectType(SdJwtVcSpec.MEDIA_SUBTYPE_VC_SD_JWT),
-                NimbusJOSEObjectType(SdJwtVcSpec.MEDIA_SUBTYPE_DC_SD_JWT),
-            )
+            NimbusDefaultJOSEObjectTypeVerifier(NimbusJOSEObjectType(SdJwtVcSpec.MEDIA_SUBTYPE_DC_SD_JWT))
 
         private fun <C : NimbusSecurityContext> claimSetVerifier(): NimbusJWTClaimsSetVerifier<C> =
             NimbusDefaultJWTClaimsVerifier(

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SelectPath.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SelectPath.kt
@@ -71,13 +71,6 @@ fun interface SelectPath {
      */
     fun JsonElement.query(path: ClaimPath): Result<Selection>
 
-    @Deprecated(
-        message = "Will be removed",
-        replaceWith = ReplaceWith("query(path).map { it.toJsonElement() }"),
-    )
-    fun JsonElement.select(path: ClaimPath): Result<JsonElement?> =
-        query(path).map { it.toJsonElement() }
-
     /**
      * Default implementation
      */

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/TypeMetadata.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/TypeMetadata.kt
@@ -16,7 +16,6 @@
 package eu.europa.ec.eudi.sdjwt.vc
 
 import eu.europa.ec.eudi.sdjwt.SdJwtVcSpec
-import eu.europa.ec.eudi.sdjwt.vc.ClaimMetadata.Companion.DefaultSelectivelyDisclosable
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -38,7 +38,7 @@ val sdJwtVcVerification = runBlocking {
             }
 
             val signer = issuer(signer = ECDSASigner(issuerEcKeyPairWithCertificate), signAlgorithm = JWSAlgorithm.ES512) {
-                type(JOSEObjectType("vc+sd-jwt"))
+                type(JOSEObjectType(SdJwtVcSpec.MEDIA_SUBTYPE_DC_SD_JWT))
                 x509CertChain(issuerEcKeyPairWithCertificate.x509CertChain)
             }
             signer.issue(spec).getOrThrow().serialize()


### PR DESCRIPTION
This PR:

1. Drops support for media type `vc+sd-jwt`. It has been superseded by `dc+sd-jwt`
2. Remove deprecated methods
3. Remove some unused imports