### PR TITLE
Fix incorrect serialization of SD-JWT+KB-JWT

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtSerialization.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtSerialization.kt
@@ -48,7 +48,7 @@ interface SdJwtSerializationOps<JWT> {
      */
     fun SdJwt<JWT>.serializeWithKeyBinding(kbJwt: Jwt): String {
         val presentationSdJwt = serialize()
-        return "$presentationSdJwt$kbJwt}"
+        return "$presentationSdJwt$kbJwt"
     }
 
     /**


### PR DESCRIPTION
The method that serializes an SD-JWT+KB, which accepts a pre-serliazed KB, incorrectly appends a `}` character as a suffix.

This PR fixes this bug.