### PR TITLE
Add Status resolution abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ gradle-app.setting
 .classpath
 
 .idea
+
+.kotlin

--- a/README.md
+++ b/README.md
@@ -513,6 +513,15 @@ The validation result (`DefinitionBasedValidationResult`) can be either:
 - `Valid`: Contains the recreated credential and disclosures per claim path
 - `Invalid`: Contains a list of specific violations (missing claims, wrong types, etc.)
 
+### Token Status List 
+
+When constructing an `SdJwtVcVerifier`, a Verifier can provide a `CheckWithTokenStatusList` implementation to check the Status
+of an SD-JWT VC from a Token Status List.
+
+If an SD-JWT VC contains a `status` claim, with a Token Status List Reference (`status_list` claim), the library will attempt to check 
+the Status in the Token Status List using the provided `CheckWithTokenStatusList` implementation, and ensure that the Status is valid. 
+
+In case Status is non-valid, the SD-JWT VC is rejected, and an error is raised.
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ val sdJwtVcVerification = runBlocking {
                 chain.first().base64 == issuerEcKeyPairWithCertificate.x509CertChain.first()
             },
             typeMetadataPolicy = TypeMetadataPolicy.NotUsed,
+            null,
         )
         verifier.verify(sdJwt)
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Specs.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Specs.kt
@@ -201,4 +201,7 @@ object RFC7800 {
  */
 object TokenStatusListSpec {
     const val STATUS: String = "status"
+    const val STATUS_LIST: String = "status_list"
+    const val INDEX: String = "idx"
+    const val URI: String = "uri"
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
@@ -47,6 +47,7 @@ internal object NimbusSdJwtVcVerifierFactory : SdJwtVcVerifierFactory<NimbusSign
     override fun invoke(
         issuerVerificationMethod: IssuerVerificationMethod<SignedJWT, JWK, List<X509Certificate>>,
         typeMetadataPolicy: TypeMetadataPolicy,
+        resolveStatus: ResolveStatus?,
     ): SdJwtVcVerifier<SignedJWT> {
         val jwtSignatureVerifier = when (issuerVerificationMethod) {
             is IssuerVerificationMethod.UsingIssuerMetadata -> sdJwtVcSignatureVerifier(
@@ -61,13 +62,14 @@ internal object NimbusSdJwtVcVerifierFactory : SdJwtVcVerifierFactory<NimbusSign
             is IssuerVerificationMethod.Custom -> issuerVerificationMethod.jwtSignatureVerifier
         }
 
-        return NimbusSdJwtVcVerifier(jwtSignatureVerifier, typeMetadataPolicy)
+        return NimbusSdJwtVcVerifier(jwtSignatureVerifier, typeMetadataPolicy, resolveStatus)
     }
 }
 
 private class NimbusSdJwtVcVerifier(
     private val jwtSignatureVerifier: JwtSignatureVerifier<NimbusSignedJWT>,
     private val typeMetadataPolicy: TypeMetadataPolicy,
+    private val resolveStatus: ResolveStatus?,
 ) : SdJwtVcVerifier<NimbusSignedJWT> {
     private fun keyBindingVerifierForSdJwtVc(challenge: JsonObject?): KeyBindingVerifier.MustBePresentAndValid<NimbusSignedJWT> =
         with(NimbusSdJwtOps) {
@@ -78,6 +80,7 @@ private class NimbusSdJwtVcVerifier(
         runCatchingCancellable {
             val sdJwt = NimbusSdJwtOps.verify(jwtSignatureVerifier, unverifiedSdJwt).getOrThrow()
             typeMetadataPolicy.validate(sdJwt)
+            resolveStatus?.ensureStatusIsValid(sdJwt)
             sdJwt
         }
 
@@ -94,6 +97,7 @@ private class NimbusSdJwtVcVerifier(
                 unverifiedSdJwt,
             ).getOrThrow()
             typeMetadataPolicy.validate(sdJwtAndKbJwt.sdJwt)
+            resolveStatus?.ensureStatusIsValid(sdJwtAndKbJwt.sdJwt)
             sdJwtAndKbJwt
         }
 }
@@ -260,5 +264,23 @@ private fun ResolvedTypeMetadata.validate(sdJwt: SdJwt<NimbusSignedJWT>): JsonOb
         is DefinitionBasedValidationResult.Invalid -> raise(
             SdJwtVcVerificationError.TypeMetadataVerificationError.TypeMetadataValidationFailure(validationResult.errors),
         )
+    }
+}
+
+private suspend fun ResolveStatus.ensureStatusIsValid(sdJwt: SdJwt<NimbusSignedJWT>) {
+    val claimSet = sdJwt.jwt.jwtClaimsSet.jsonObject()
+    val statusReference = claimSet[TokenStatusListSpec.STATUS]
+        ?.let {
+            check(it is JsonObject) { "'${TokenStatusListSpec.STATUS}' claim must be a JsonObject" }
+            it
+        }
+    if (null != statusReference) {
+        val status = runCatchingCancellable {
+            this(statusReference)
+        }.getOrElse { raise(SdJwtVcVerificationError.StatusVerificationError.StatusResolutionFailure(it)) }
+
+        if (status is Status.Invalid) {
+            raise(SdJwtVcVerificationError.StatusVerificationError.StatusIsNotValid(status))
+        }
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
@@ -16,6 +16,8 @@
 package eu.europa.ec.eudi.sdjwt.vc
 
 import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jose.util.JSONObjectUtils
+import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.sdjwt.*
 import eu.europa.ec.eudi.sdjwt.dsl.def.DefinitionBasedSdJwtVcValidator
@@ -24,14 +26,22 @@ import eu.europa.ec.eudi.sdjwt.dsl.def.SdJwtDefinition
 import eu.europa.ec.eudi.sdjwt.dsl.def.fromSdJwtVcMetadata
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcIssuerPublicKeySource.*
 import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerificationError.IssuerKeyVerificationError.*
+import eu.europa.ec.eudi.sdjwt.vc.SdJwtVcVerificationError.StatusVerificationError
 import io.ktor.client.*
 import io.ktor.http.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Required
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.serializer
 import java.security.cert.X509Certificate
 import java.text.ParseException
 import com.nimbusds.jose.jwk.JWK as NimbusJWK
@@ -47,7 +57,7 @@ internal object NimbusSdJwtVcVerifierFactory : SdJwtVcVerifierFactory<NimbusSign
     override fun invoke(
         issuerVerificationMethod: IssuerVerificationMethod<SignedJWT, JWK, List<X509Certificate>>,
         typeMetadataPolicy: TypeMetadataPolicy,
-        resolveStatus: ResolveStatus?,
+        checkStatus: CheckWithTokenStatusList?,
     ): SdJwtVcVerifier<SignedJWT> {
         val jwtSignatureVerifier = when (issuerVerificationMethod) {
             is IssuerVerificationMethod.UsingIssuerMetadata -> sdJwtVcSignatureVerifier(
@@ -62,14 +72,14 @@ internal object NimbusSdJwtVcVerifierFactory : SdJwtVcVerifierFactory<NimbusSign
             is IssuerVerificationMethod.Custom -> issuerVerificationMethod.jwtSignatureVerifier
         }
 
-        return NimbusSdJwtVcVerifier(jwtSignatureVerifier, typeMetadataPolicy, resolveStatus)
+        return NimbusSdJwtVcVerifier(jwtSignatureVerifier, typeMetadataPolicy, checkStatus)
     }
 }
 
 private class NimbusSdJwtVcVerifier(
     private val jwtSignatureVerifier: JwtSignatureVerifier<NimbusSignedJWT>,
     private val typeMetadataPolicy: TypeMetadataPolicy,
-    private val resolveStatus: ResolveStatus?,
+    private val checkStatus: CheckWithTokenStatusList?,
 ) : SdJwtVcVerifier<NimbusSignedJWT> {
     private fun keyBindingVerifierForSdJwtVc(challenge: JsonObject?): KeyBindingVerifier.MustBePresentAndValid<NimbusSignedJWT> =
         with(NimbusSdJwtOps) {
@@ -80,7 +90,7 @@ private class NimbusSdJwtVcVerifier(
         runCatchingCancellable {
             val sdJwt = NimbusSdJwtOps.verify(jwtSignatureVerifier, unverifiedSdJwt).getOrThrow()
             typeMetadataPolicy.validate(sdJwt)
-            resolveStatus?.ensureStatusIsValid(sdJwt)
+            checkStatus?.ensureStatusIsValid(sdJwt)
             sdJwt
         }
 
@@ -97,7 +107,7 @@ private class NimbusSdJwtVcVerifier(
                 unverifiedSdJwt,
             ).getOrThrow()
             typeMetadataPolicy.validate(sdJwtAndKbJwt.sdJwt)
-            resolveStatus?.ensureStatusIsValid(sdJwtAndKbJwt.sdJwt)
+            checkStatus?.ensureStatusIsValid(sdJwtAndKbJwt.sdJwt)
             sdJwtAndKbJwt
         }
 }
@@ -267,20 +277,46 @@ private fun ResolvedTypeMetadata.validate(sdJwt: SdJwt<NimbusSignedJWT>): JsonOb
     }
 }
 
-private suspend fun ResolveStatus.ensureStatusIsValid(sdJwt: SdJwt<NimbusSignedJWT>) {
-    val claimSet = sdJwt.jwt.jwtClaimsSet.jsonObject()
-    val statusReference = claimSet[TokenStatusListSpec.STATUS]
-        ?.let {
-            check(it is JsonObject) { "'${TokenStatusListSpec.STATUS}' claim must be a JsonObject" }
-            it
-        }
-    if (null != statusReference) {
-        val status = runCatchingCancellable {
-            this(statusReference)
-        }.getOrElse { raise(SdJwtVcVerificationError.StatusVerificationError.StatusResolutionFailure(it)) }
+private suspend fun CheckWithTokenStatusList.ensureStatusIsValid(sdJwt: SdJwt<NimbusSignedJWT>) {
+    val statusListReference = sdJwt.jwt.jwtClaimsSet.jsonObjectClaim(TokenStatusListSpec.STATUS)
+        .getOrElse { raise(StatusVerificationError.StatusCheckFailure("'${TokenStatusListSpec.STATUS}' claim must be a JsonObject", it)) }
+        ?.decodeAs<StatusClaim>()
+        ?.getOrElse { raise(StatusVerificationError.StatusCheckFailure("'${TokenStatusListSpec.STATUS}' claim is malformed", it)) }
+        ?.statusListReference
 
-        if (status is Status.Invalid) {
-            raise(SdJwtVcVerificationError.StatusVerificationError.StatusIsNotValid(status))
+    if (null != statusListReference) {
+        val status = runCatchingCancellable {
+            invoke(statusListReference.uri, statusListReference.index)
+        }.getOrElse { raise(StatusVerificationError.StatusCheckFailure("Unable to check Status in Token Status List", it)) }
+
+        if (status is Status.NonValid) {
+            raise(StatusVerificationError.NonValidStatus(status))
         }
     }
 }
+
+@Serializable
+@JsonIgnoreUnknownKeys
+private data class StatusClaim(
+    @SerialName(TokenStatusListSpec.STATUS_LIST) val statusListReference: StatusListReferenceClaim? = null,
+)
+
+@Serializable
+private data class StatusListReferenceClaim(
+    @Required @SerialName(TokenStatusListSpec.INDEX) val index: UInt,
+    @Required @SerialName(TokenStatusListSpec.URI) val uri: String,
+)
+
+private fun JWTClaimsSet.jsonObjectClaim(claim: String): Result<JsonObject?> =
+    runCatching {
+        getJSONObjectClaim(claim)
+            ?.let {
+                val serialized = JSONObjectUtils.toJSONString(it)
+                Json.decodeFromString<JsonObject>(serialized)
+            }
+    }
+
+private inline fun <reified T : Any> JsonElement.decodeAs(serializer: KSerializer<T> = serializer<T>()): Result<T> =
+    runCatching {
+        Json.decodeFromJsonElement(serializer, this)
+    }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -154,6 +154,21 @@ sealed interface SdJwtVcVerificationError {
             }
         }
     }
+
+    /**
+     * Verification error regarding Status resolution and validation.
+     */
+    sealed interface StatusVerificationError : SdJwtVcVerificationError {
+        /**
+         * Status could not be resolved.
+         */
+        class StatusResolutionFailure(val cause: Throwable) : StatusVerificationError
+
+        /**
+         * The Status of an SD-JWT VC is not valid.
+         */
+        class StatusIsNotValid(val invalid: Status.Invalid) : StatusVerificationError
+    }
 }
 
 internal fun raise(error: SdJwtVcVerificationError): Nothing = throw SdJwtVerificationException(VerificationError.SdJwtVcError(error))

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -156,18 +156,18 @@ sealed interface SdJwtVcVerificationError {
     }
 
     /**
-     * Verification error regarding Status resolution and validation.
+     * Verification error regarding Status check and validation.
      */
     sealed interface StatusVerificationError : SdJwtVcVerificationError {
         /**
-         * Status could not be resolved.
+         * Status could not be checked.
          */
-        class StatusResolutionFailure(val cause: Throwable) : StatusVerificationError
+        class StatusCheckFailure(val message: String, val cause: Throwable) : StatusVerificationError
 
         /**
-         * The Status of an SD-JWT VC is not valid.
+         * The Status of an SD-JWT VC is non-valid.
          */
-        class StatusIsNotValid(val invalid: Status.Invalid) : StatusVerificationError
+        data class NonValidStatus(val status: Status.NonValid) : StatusVerificationError
     }
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
@@ -177,6 +177,7 @@ interface SdJwtVcVerifierFactory<JWT, in JWK, out X509Chain> {
     operator fun invoke(
         issuerVerificationMethod: IssuerVerificationMethod<JWT, JWK, X509Chain>,
         typeMetadataPolicy: TypeMetadataPolicy,
+        resolveStatus: ResolveStatus?,
     ): SdJwtVcVerifier<JWT>
 
     fun <JWT1, JWK1, X509Chain1> transform(
@@ -189,10 +190,12 @@ interface SdJwtVcVerifierFactory<JWT, in JWK, out X509Chain> {
             override fun invoke(
                 issuerVerificationMethod: IssuerVerificationMethod<JWT1, JWK1, X509Chain1>,
                 typeMetadataPolicy: TypeMetadataPolicy,
+                resolveStatus: ResolveStatus?,
             ): SdJwtVcVerifier<JWT1> =
                 this@SdJwtVcVerifierFactory.invoke(
                     issuerVerificationMethod.transform(convertFromJwt, convertFromJwk, convertToX509Chain),
                     typeMetadataPolicy,
+                    resolveStatus,
                 ).map(convertToJwt)
         }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
@@ -177,7 +177,7 @@ interface SdJwtVcVerifierFactory<JWT, in JWK, out X509Chain> {
     operator fun invoke(
         issuerVerificationMethod: IssuerVerificationMethod<JWT, JWK, X509Chain>,
         typeMetadataPolicy: TypeMetadataPolicy,
-        resolveStatus: ResolveStatus?,
+        checkStatus: CheckWithTokenStatusList?,
     ): SdJwtVcVerifier<JWT>
 
     fun <JWT1, JWK1, X509Chain1> transform(
@@ -190,12 +190,12 @@ interface SdJwtVcVerifierFactory<JWT, in JWK, out X509Chain> {
             override fun invoke(
                 issuerVerificationMethod: IssuerVerificationMethod<JWT1, JWK1, X509Chain1>,
                 typeMetadataPolicy: TypeMetadataPolicy,
-                resolveStatus: ResolveStatus?,
+                checkStatus: CheckWithTokenStatusList?,
             ): SdJwtVcVerifier<JWT1> =
                 this@SdJwtVcVerifierFactory.invoke(
                     issuerVerificationMethod.transform(convertFromJwt, convertFromJwk, convertToX509Chain),
                     typeMetadataPolicy,
-                    resolveStatus,
+                    checkStatus,
                 ).map(convertToJwt)
         }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/Status.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/Status.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt.vc
+
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * The status of an SD-JWT VC.
+ */
+sealed interface Status {
+    data object Valid : Status
+    class Invalid(val message: String, val cause: Throwable?) : Status
+}
+
+/**
+ * Resolves the status of an SD-JWT VC given the contents of the `status` claim.
+ */
+fun interface ResolveStatus {
+    suspend operator fun invoke(status: JsonObject): Status
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/Status.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/Status.kt
@@ -20,7 +20,7 @@ package eu.europa.ec.eudi.sdjwt.vc
  */
 sealed interface Status {
     data object Valid : Status
-    data class NonValid(val value: UByte) : Status
+    data class NonValid(val status: UByte, val explanation: String) : Status
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/Status.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/Status.kt
@@ -15,19 +15,17 @@
  */
 package eu.europa.ec.eudi.sdjwt.vc
 
-import kotlinx.serialization.json.JsonObject
-
 /**
  * The status of an SD-JWT VC.
  */
 sealed interface Status {
     data object Valid : Status
-    class Invalid(val message: String, val cause: Throwable?) : Status
+    data class NonValid(val value: UByte) : Status
 }
 
 /**
- * Resolves the status of an SD-JWT VC given the contents of the `status` claim.
+ * Checks the status of an SD-JWT VC in a Token Status List.
  */
-fun interface ResolveStatus {
-    suspend operator fun invoke(status: JsonObject): Status
+fun interface CheckWithTokenStatusList {
+    suspend operator fun invoke(uri: String, index: UInt): Status
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -64,6 +64,7 @@ class KeyBindingTest {
                 .map { nimbusToJwtAndClaims(it) },
         ),
         TypeMetadataPolicy.NotUsed,
+        null,
     )
     private val holder = HolderActor(genKey("holder"), verifier = verifier)
 

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/PidDevVerificationTest.kt
@@ -53,6 +53,7 @@ class PidDevVerificationTest :
                 x509CertificateTrust = { _, _ -> true },
             ),
             TypeMetadataPolicy.NotUsed,
+            null,
         )
 
         val issuedSdJwt = try {

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/examples/ExampleSdJwtVcVerification01.kt
@@ -49,6 +49,7 @@ val sdJwtVcVerification = runBlocking {
                 chain.first().base64 == issuerEcKeyPairWithCertificate.x509CertChain.first()
             },
             typeMetadataPolicy = TypeMetadataPolicy.NotUsed,
+            null,
         )
         verifier.verify(sdJwt)
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcIssuanceTest.kt
@@ -162,6 +162,7 @@ class SdJwtVcIssuanceTest {
             },
         ),
         TypeMetadataPolicy.NotUsed,
+        null,
     )
 
     @Test

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
@@ -60,6 +60,7 @@ class SdJwtVcVerifierIntegrationTest {
                 },
             ),
         ),
+        null,
     )
 
     private suspend fun issue(builder: SdJwtObjectBuilder.() -> Unit): String = issuer.issue(sdJwt { builder() }).getOrThrow().serialize()
@@ -159,6 +160,7 @@ class SdJwtVcVerifierIntegrationTest {
                     },
                 ),
             ),
+            null,
         )
 
         verifier.verify(serialized).getOrThrow()

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
@@ -269,7 +269,7 @@ class SdJwtVcVerifierIntegrationTest {
         val checkStatus = CheckWithTokenStatusList { uri, index ->
             assertEquals("https://example.com/status_list/10", uri)
             assertEquals(4u, index)
-            Status.NonValid(0x01u)
+            Status.NonValid(0x01u, "revoked")
         }
         val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
             issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
@@ -279,7 +279,7 @@ class SdJwtVcVerifierIntegrationTest {
         val exception = assertFailsWith<SdJwtVerificationException> { verifier.verify(serialized).getOrThrow() }
         val error = assertIs<VerificationError.SdJwtVcError>(exception.reason)
         val reason = assertIs<SdJwtVcVerificationError.StatusVerificationError.NonValidStatus>(error.error)
-        assertEquals(0x01u, reason.status.value)
+        assertEquals(0x01u, reason.status.status)
     }
 
     @Test

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
@@ -166,4 +166,107 @@ class SdJwtVcVerifierIntegrationTest {
         verifier.verify(serialized).getOrThrow()
         assertTrue(documentIntegrityParsed)
     }
+
+    @Test
+    fun `when status reference is not present, status resolver is not invoked`() = runTest {
+        val serialized = issue {
+            claim(RFC7519.ISSUER, "https://example.com/issuer")
+            claim(SdJwtVcSpec.VCT, "urn:eudi:ehic:1")
+        }
+        val resolveStatus = ResolveStatus { fail("Status resolver should not be invoked") }
+        val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
+            issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
+            TypeMetadataPolicy.NotUsed,
+            resolveStatus,
+        )
+        verifier.verify(serialized).getOrThrow()
+    }
+
+    @Test
+    fun `when status reference is not a json object, verification fails`() = runTest {
+        val serialized = issue {
+            claim(RFC7519.ISSUER, "https://example.com/issuer")
+            claim(SdJwtVcSpec.VCT, "urn:eudi:ehic:1")
+            claim(TokenStatusListSpec.STATUS, "status")
+        }
+        val resolveStatus = ResolveStatus { fail("Status resolver should not be invoked") }
+        val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
+            issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
+            TypeMetadataPolicy.NotUsed,
+            resolveStatus,
+        )
+        val exception = assertFailsWith<IllegalStateException> { verifier.verify(serialized).getOrThrow() }
+        assertEquals("'status' claim must be a JsonObject", exception.message)
+    }
+
+    @Test
+    fun `when status resolution fails, verification fails`() = runTest {
+        val serialized = issue {
+            claim(RFC7519.ISSUER, "https://example.com/issuer")
+            claim(SdJwtVcSpec.VCT, "urn:eudi:ehic:1")
+            objClaim(TokenStatusListSpec.STATUS) {
+                objClaim("status_list") {
+                    claim("idx", 4)
+                    claim("uri", "https://example.com/status_list/10")
+                }
+            }
+        }
+        val resolveStatus = ResolveStatus { error("resolution failed") }
+        val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
+            issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
+            TypeMetadataPolicy.NotUsed,
+            resolveStatus,
+        )
+        val exception = assertFailsWith<SdJwtVerificationException> { verifier.verify(serialized).getOrThrow() }
+        val error = assertIs<VerificationError.SdJwtVcError>(exception.reason)
+        val reason = assertIs<SdJwtVcVerificationError.StatusVerificationError.StatusResolutionFailure>(error.error)
+        assertIs<IllegalStateException>(reason.cause)
+        assertEquals("resolution failed", reason.cause.message)
+    }
+
+    @Test
+    fun `when status is not valid, verification fails`() = runTest {
+        val serialized = issue {
+            claim(RFC7519.ISSUER, "https://example.com/issuer")
+            claim(SdJwtVcSpec.VCT, "urn:eudi:ehic:1")
+            objClaim(TokenStatusListSpec.STATUS) {
+                objClaim("status_list") {
+                    claim("idx", 4)
+                    claim("uri", "https://example.com/status_list/10")
+                }
+            }
+        }
+        val resolveStatus = ResolveStatus { Status.Invalid("not valid", null) }
+        val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
+            issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
+            TypeMetadataPolicy.NotUsed,
+            resolveStatus,
+        )
+        val exception = assertFailsWith<SdJwtVerificationException> { verifier.verify(serialized).getOrThrow() }
+        val error = assertIs<VerificationError.SdJwtVcError>(exception.reason)
+        val reason = assertIs<SdJwtVcVerificationError.StatusVerificationError.StatusIsNotValid>(error.error)
+        assertEquals("not valid", reason.invalid.message)
+        assertNull(reason.invalid.cause)
+    }
+
+    @Test
+    fun `when status is valid, verification succeeds`() = runTest {
+        val serialized = issue {
+            claim(RFC7519.ISSUER, "https://example.com/issuer")
+            claim(SdJwtVcSpec.VCT, "urn:eudi:ehic:1")
+            objClaim(TokenStatusListSpec.STATUS) {
+                objClaim("status_list") {
+                    claim("idx", 4)
+                    claim("uri", "https://example.com/status_list/10")
+                }
+            }
+        }
+        val resolveStatus = ResolveStatus { Status.Valid }
+        val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
+            issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
+            TypeMetadataPolicy.NotUsed,
+            resolveStatus,
+        )
+        verifier.verify(serialized).getOrThrow()
+    }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
@@ -280,6 +280,7 @@ class SdJwtVcVerifierIntegrationTest {
         val error = assertIs<VerificationError.SdJwtVcError>(exception.reason)
         val reason = assertIs<SdJwtVcVerificationError.StatusVerificationError.NonValidStatus>(error.error)
         assertEquals(0x01u, reason.status.status)
+        assertEquals("revoked", reason.status.explanation)
     }
 
     @Test

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierIntegrationTest.kt
@@ -173,11 +173,11 @@ class SdJwtVcVerifierIntegrationTest {
             claim(RFC7519.ISSUER, "https://example.com/issuer")
             claim(SdJwtVcSpec.VCT, "urn:eudi:ehic:1")
         }
-        val resolveStatus = ResolveStatus { fail("Status resolver should not be invoked") }
+        val checkStatus = CheckWithTokenStatusList { _, _ -> fail("CheckWithTokenStatusList should not have been invoked") }
         val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
             issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
             TypeMetadataPolicy.NotUsed,
-            resolveStatus,
+            checkStatus,
         )
         verifier.verify(serialized).getOrThrow()
     }
@@ -189,14 +189,40 @@ class SdJwtVcVerifierIntegrationTest {
             claim(SdJwtVcSpec.VCT, "urn:eudi:ehic:1")
             claim(TokenStatusListSpec.STATUS, "status")
         }
-        val resolveStatus = ResolveStatus { fail("Status resolver should not be invoked") }
+        val checkStatus = CheckWithTokenStatusList { _, _ -> fail("CheckWithTokenStatusList should not have been invoked") }
         val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
             issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
             TypeMetadataPolicy.NotUsed,
-            resolveStatus,
+            checkStatus,
         )
-        val exception = assertFailsWith<IllegalStateException> { verifier.verify(serialized).getOrThrow() }
-        assertEquals("'status' claim must be a JsonObject", exception.message)
+        val exception = assertFailsWith<SdJwtVerificationException> { verifier.verify(serialized).getOrThrow() }
+        val error = assertIs<VerificationError.SdJwtVcError>(exception.reason)
+        val reason = assertIs<SdJwtVcVerificationError.StatusVerificationError.StatusCheckFailure>(error.error)
+        assertEquals("'status' claim must be a JsonObject", reason.message)
+    }
+
+    @Test
+    fun `when status list reference is malformed, verification fails`() = runTest {
+        val serialized = issue {
+            claim(RFC7519.ISSUER, "https://example.com/issuer")
+            claim(SdJwtVcSpec.VCT, "urn:eudi:ehic:1")
+            objClaim(TokenStatusListSpec.STATUS) {
+                objClaim(TokenStatusListSpec.STATUS_LIST) {
+                    claim(TokenStatusListSpec.INDEX, "index")
+                    claim(TokenStatusListSpec.URI, 1)
+                }
+            }
+        }
+        val checkStatus = CheckWithTokenStatusList { _, _ -> fail("CheckWithTokenStatusList should not have been invoked") }
+        val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
+            issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
+            TypeMetadataPolicy.NotUsed,
+            checkStatus,
+        )
+        val exception = assertFailsWith<SdJwtVerificationException> { verifier.verify(serialized).getOrThrow() }
+        val error = assertIs<VerificationError.SdJwtVcError>(exception.reason)
+        val reason = assertIs<SdJwtVcVerificationError.StatusVerificationError.StatusCheckFailure>(error.error)
+        assertEquals("'status' claim is malformed", reason.message)
     }
 
     @Test
@@ -205,48 +231,55 @@ class SdJwtVcVerifierIntegrationTest {
             claim(RFC7519.ISSUER, "https://example.com/issuer")
             claim(SdJwtVcSpec.VCT, "urn:eudi:ehic:1")
             objClaim(TokenStatusListSpec.STATUS) {
-                objClaim("status_list") {
-                    claim("idx", 4)
-                    claim("uri", "https://example.com/status_list/10")
+                objClaim(TokenStatusListSpec.STATUS_LIST) {
+                    claim(TokenStatusListSpec.INDEX, 4)
+                    claim(TokenStatusListSpec.URI, "https://example.com/status_list/10")
                 }
             }
         }
-        val resolveStatus = ResolveStatus { error("resolution failed") }
+        val checkStatus = CheckWithTokenStatusList { uri, index ->
+            assertEquals("https://example.com/status_list/10", uri)
+            assertEquals(4u, index)
+            error("resolution failed")
+        }
         val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
             issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
             TypeMetadataPolicy.NotUsed,
-            resolveStatus,
+            checkStatus,
         )
         val exception = assertFailsWith<SdJwtVerificationException> { verifier.verify(serialized).getOrThrow() }
         val error = assertIs<VerificationError.SdJwtVcError>(exception.reason)
-        val reason = assertIs<SdJwtVcVerificationError.StatusVerificationError.StatusResolutionFailure>(error.error)
+        val reason = assertIs<SdJwtVcVerificationError.StatusVerificationError.StatusCheckFailure>(error.error)
         assertIs<IllegalStateException>(reason.cause)
         assertEquals("resolution failed", reason.cause.message)
     }
 
     @Test
-    fun `when status is not valid, verification fails`() = runTest {
+    fun `when status is non-valid, verification fails`() = runTest {
         val serialized = issue {
             claim(RFC7519.ISSUER, "https://example.com/issuer")
             claim(SdJwtVcSpec.VCT, "urn:eudi:ehic:1")
             objClaim(TokenStatusListSpec.STATUS) {
-                objClaim("status_list") {
-                    claim("idx", 4)
-                    claim("uri", "https://example.com/status_list/10")
+                objClaim(TokenStatusListSpec.STATUS_LIST) {
+                    claim(TokenStatusListSpec.INDEX, 4)
+                    claim(TokenStatusListSpec.URI, "https://example.com/status_list/10")
                 }
             }
         }
-        val resolveStatus = ResolveStatus { Status.Invalid("not valid", null) }
+        val checkStatus = CheckWithTokenStatusList { uri, index ->
+            assertEquals("https://example.com/status_list/10", uri)
+            assertEquals(4u, index)
+            Status.NonValid(0x01u)
+        }
         val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
             issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
             TypeMetadataPolicy.NotUsed,
-            resolveStatus,
+            checkStatus,
         )
         val exception = assertFailsWith<SdJwtVerificationException> { verifier.verify(serialized).getOrThrow() }
         val error = assertIs<VerificationError.SdJwtVcError>(exception.reason)
-        val reason = assertIs<SdJwtVcVerificationError.StatusVerificationError.StatusIsNotValid>(error.error)
-        assertEquals("not valid", reason.invalid.message)
-        assertNull(reason.invalid.cause)
+        val reason = assertIs<SdJwtVcVerificationError.StatusVerificationError.NonValidStatus>(error.error)
+        assertEquals(0x01u, reason.status.value)
     }
 
     @Test
@@ -255,17 +288,21 @@ class SdJwtVcVerifierIntegrationTest {
             claim(RFC7519.ISSUER, "https://example.com/issuer")
             claim(SdJwtVcSpec.VCT, "urn:eudi:ehic:1")
             objClaim(TokenStatusListSpec.STATUS) {
-                objClaim("status_list") {
-                    claim("idx", 4)
-                    claim("uri", "https://example.com/status_list/10")
+                objClaim(TokenStatusListSpec.STATUS_LIST) {
+                    claim(TokenStatusListSpec.INDEX, 4)
+                    claim(TokenStatusListSpec.URI, "https://example.com/status_list/10")
                 }
             }
         }
-        val resolveStatus = ResolveStatus { Status.Valid }
+        val checkStatus = CheckWithTokenStatusList { uri, index ->
+            assertEquals("https://example.com/status_list/10", uri)
+            assertEquals(4u, index)
+            Status.Valid
+        }
         val verifier = NimbusSdJwtOps.SdJwtVcVerifier(
             issuerVerificationMethod = IssuerVerificationMethod.usingCustom(ECDSAVerifier(issuerKey).asJwtVerifier()),
             TypeMetadataPolicy.NotUsed,
-            resolveStatus,
+            checkStatus,
         )
         verifier.verify(serialized).getOrThrow()
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -159,6 +159,7 @@ class SdJwtVcVerifierTest {
         val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
             IssuerVerificationMethod.usingIssuerMetadata(HttpMock.clientReturning(SampleIssuer.issuerMeta)),
             TypeMetadataPolicy.NotUsed,
+            null,
         )
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
@@ -169,6 +170,7 @@ class SdJwtVcVerifierTest {
         val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
             IssuerVerificationMethod.usingIssuerMetadata(HttpMock.clientReturning(SampleIssuer.issuerMeta)),
             TypeMetadataPolicy.NotUsed,
+            null,
         )
         verifier.verify(unverifiedSdJwt).getOrThrow()
     }
@@ -180,6 +182,7 @@ class SdJwtVcVerifierTest {
         val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
             IssuerVerificationMethod.usingIssuerMetadata(HttpMock.clientReturning(SampleIssuer.issuerMeta)),
             TypeMetadataPolicy.NotUsed,
+            null,
         )
         try {
             verifier.verify(unverifiedSdJwt).getOrThrow()
@@ -240,6 +243,7 @@ class SdJwtVcVerifierTest {
             val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
                 IssuerVerificationMethod.usingIssuerMetadata(httpClient),
                 TypeMetadataPolicy.NotUsed,
+                null,
             )
 
             val serialized = with(NimbusSdJwtOps) { sdJwt.serialize() }
@@ -297,6 +301,7 @@ class SdJwtVcVerifierTest {
             NimbusSdJwtOps.SdJwtVcVerifier(
                 IssuerVerificationMethod.usingX5c(x509CertificateTrust),
                 TypeMetadataPolicy.NotUsed,
+                null,
             )
         }
 


### PR DESCRIPTION
This PR adds a new abstraction `CheckWithTokenStatusList`.

This new abstraction is used to resolve the Status of an SD-JWT VC, during verification, when `status` is present and is a `JsonObject`.

If an `SdJwtVcVerifier` is instantiated with a `CheckWithTokenStatusList` instance, during SD-JWT VC verification if the SD-JWT VC contains a `status` claim and contains a Token Status List reference (`status_list`):
1. The `Status` of the SD-JWT VC is fetched using the provided `CheckWithTokenStatusList` instance
2. We ensure that `Status` is `Valid`

In case `CheckWithTokenStatusList` fails, or `Status` is `NonValid`, the SD-JWT VC is rejected with an `SdJwtVcVerificationError`.

Closes #453 