### PR TITLE
Reject an SD-JWT/SD-JWT VC when a Disclosure contains a claim with a reserved name

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Disclosure.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Disclosure.kt
@@ -68,8 +68,15 @@ sealed interface Disclosure {
             val array = Json.decodeFromString<JsonArray>(base64Decoded)
             when (array.size) {
                 3 -> {
+                    fun String.ensureNotReserved() {
+                        val reserved = setOf(RFC9901.CLAIM_SD, RFC9901.CLAIM_ARRAY_ELEMENT_DIGEST)
+                        require(this !in reserved) {
+                            "Disclosed claim cannot be one of: ${reserved.joinToString()}"
+                        }
+                    }
+
                     val salt = array[0].jsonPrimitive.content
-                    val claimName = array[1].jsonPrimitive.content
+                    val claimName = array[1].jsonPrimitive.content.also { it.ensureNotReserved() }
                     val claimValue = array[2]
                     Triple(salt, claimName, claimValue)
                 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Disclosure.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/Disclosure.kt
@@ -68,15 +68,8 @@ sealed interface Disclosure {
             val array = Json.decodeFromString<JsonArray>(base64Decoded)
             when (array.size) {
                 3 -> {
-                    fun String.ensureNotReserved() {
-                        val reserved = setOf(RFC9901.CLAIM_SD, RFC9901.CLAIM_ARRAY_ELEMENT_DIGEST)
-                        require(this !in reserved) {
-                            "Disclosed claim cannot be one of: ${reserved.joinToString()}"
-                        }
-                    }
-
                     val salt = array[0].jsonPrimitive.content
-                    val claimName = array[1].jsonPrimitive.content.also { it.ensureNotReserved() }
+                    val claimName = array[1].jsonPrimitive.content.also { it.ensureValidAttributeName() }
                     val claimValue = array[2]
                     Triple(salt, claimName, claimValue)
                 }
@@ -116,29 +109,27 @@ sealed interface Disclosure {
         internal fun objectProperty(
             saltProvider: SaltProvider = SaltProvider.Default,
             claim: Claim,
-        ): Result<ObjectProperty> {
-            fun Claim.ensureValidAttributeName() {
-                val reserved = setOf(RFC9901.CLAIM_SD_ALG, RFC9901.CLAIM_SD, RFC9901.CLAIM_ARRAY_ELEMENT_DIGEST)
-                require(name() !in reserved) {
-                    "Given claim should not contain an attribute named ${reserved.joinToString(separator = ", or")}"
-                }
-            }
+        ): Result<ObjectProperty> = runCatchingCancellable {
+            // Make sure that the claim name is valid
+            claim.name().ensureValidAttributeName()
 
-            return runCatchingCancellable {
-                // Make sure that the claim name is valid
-                claim.ensureValidAttributeName()
-
-                // Create a Json Array [salt, claimName, claimValue]
-                val jsonArray = buildJsonArray {
-                    add(JsonPrimitive(saltProvider.salt())) // salt
-                    add(claim.name()) // claim name
-                    add(claim.value()) // claim value
-                }
-                val jsonArrayStr = jsonArray.toString()
-                // Base64-url-encoded
-                val encoded = Base64UrlNoPadding.encode(jsonArrayStr.encodeToByteArray())
-                ObjectProperty(encoded)
+            // Create a Json Array [salt, claimName, claimValue]
+            val jsonArray = buildJsonArray {
+                add(JsonPrimitive(saltProvider.salt())) // salt
+                add(claim.name()) // claim name
+                add(claim.value()) // claim value
             }
+            val jsonArrayStr = jsonArray.toString()
+            // Base64-url-encoded
+            val encoded = Base64UrlNoPadding.encode(jsonArrayStr.encodeToByteArray())
+            ObjectProperty(encoded)
         }
+    }
+}
+
+private fun String.ensureValidAttributeName() {
+    val reserved = setOf(RFC9901.CLAIM_SD_ALG, RFC9901.CLAIM_SD, RFC9901.CLAIM_ARRAY_ELEMENT_DIGEST)
+    require(this !in reserved) {
+        "Given claim should not contain an attribute named ${reserved.joinToString(separator = ", or ")}"
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOpsTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOpsTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.sdjwt
+
+import org.junit.jupiter.api.Nested
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class DefaultSdJwtOpsTest {
+
+    @Nested
+    inner class UnverifiedIssuanceFromTest {
+
+        @Test
+        fun `when sd-jwt contains disclosures with claims with reserved names, verification fails`() {
+            fun test(disclosure: String) {
+                val exception = assertFailsWith<SdJwtVerificationException> {
+                    DefaultSdJwtOps.unverifiedIssuanceFrom("$jwt~$disclosure~").getOrThrow()
+                }
+                val error = assertIs<VerificationError.InvalidDisclosures>(exception.reason)
+                val invalidDisclosures = error.invalidDisclosures
+                assertEquals(1, invalidDisclosures.size)
+                assertEquals("Disclosed claim cannot be one of: _sd, ...", invalidDisclosures.keys.first())
+            }
+
+            // _sd
+            test("WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsIl9zZCIsIk3DtmJpdXMiXQ")
+
+            // ...
+            test("WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsIi4uLiIsIk3DtmJpdXMiXQ")
+        }
+    }
+}
+
+private val jwt =
+    """
+        eyJ0eXAiOiJzZCtqd3QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGU
+        uY29tL2lzc3VlciIsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoxODA0MjI5MDUzLCJzdWIiOiI
+        2YzVjMGE0OS1iNTg5LTQzMWQtYmFlNy0yMTkxMjJhOWVjMmMiLCJuYmYiOjE1MTYyMzkwMjI
+        sImF1ZCI6InRlc3QifQ.r1To6Mgu64GUuKdTngt0ElcqQOZS8tGIZ39BhyzM5xGF5TFVeuVr
+        yr46v-tnfBsSa9PX9bQDCmkEsPpzyQaLJA
+    """.trimIndent().removeNewLine()

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOpsTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DefaultSdJwtOpsTest.kt
@@ -35,7 +35,7 @@ class DefaultSdJwtOpsTest {
                 val error = assertIs<VerificationError.InvalidDisclosures>(exception.reason)
                 val invalidDisclosures = error.invalidDisclosures
                 assertEquals(1, invalidDisclosures.size)
-                assertEquals("Disclosed claim cannot be one of: _sd, ...", invalidDisclosures.keys.first())
+                assertEquals("Given claim should not contain an attribute named _sd_alg, or _sd, or ...", invalidDisclosures.keys.first())
             }
 
             // _sd

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DisclosureTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DisclosureTest.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.eudi.sdjwt
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
 class DisclosureTest {
@@ -43,6 +44,20 @@ class DisclosureTest {
         assertEquals(expectedSalt, salt)
         assertNotNull(name)
         assertEquals(expectedClaim, name to value)
+    }
+
+    @Test
+    fun `fails to decode disclosures with reserved claims`() {
+        fun test(disclosure: String) {
+            val exception = assertFailsWith<IllegalArgumentException> { Disclosure.decode(disclosure).getOrThrow() }
+            assertEquals("Disclosed claim cannot be one of: _sd, ...", exception.message)
+        }
+
+        // _sd
+        test("WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsIl9zZCIsIk3DtmJpdXMiXQ")
+
+        // ...
+        test("WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsIi4uLiIsIk3DtmJpdXMiXQ")
     }
 
     private fun fixedSaltProvider(s: String): SaltProvider =

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DisclosureTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/DisclosureTest.kt
@@ -50,7 +50,7 @@ class DisclosureTest {
     fun `fails to decode disclosures with reserved claims`() {
         fun test(disclosure: String) {
             val exception = assertFailsWith<IllegalArgumentException> { Disclosure.decode(disclosure).getOrThrow() }
-            assertEquals("Disclosed claim cannot be one of: _sd, ...", exception.message)
+            assertEquals("Given claim should not contain an attribute named _sd_alg, or _sd, or ...", exception.message)
         }
 
         // _sd

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierTest.kt
@@ -19,6 +19,8 @@ import eu.europa.ec.eudi.sdjwt.DefaultSdJwtOps.NoSignatureValidation
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlin.time.Clock
@@ -42,6 +44,26 @@ class SdJwtVerifierTest {
     fun `when sd-jwt is expired, verification fails`() = runTest {
         val verifier = SdJwtVerifier(Clock.fixed(Instant.fromEpochSeconds(1804229054L)))
         verifier.verifyExpectingError(VerificationError.InvalidJwt("SD-JWT is expired"), "$jwt~")
+    }
+
+    @Test
+    fun `when sd-jwt contains disclosures with claims with reserved names, verification fails`() = runTest {
+        val verifier = SdJwtVerifier(Clock.fixed(Instant.fromEpochSeconds(1772703040L)))
+
+        suspend fun test(disclosure: String) {
+            val exception =
+                assertFailsWith<SdJwtVerificationException> { verifier.verify(NoSignatureValidation, "$jwt~$disclosure~").getOrThrow() }
+            val error = assertIs<VerificationError.InvalidDisclosures>(exception.reason)
+            val invalidDisclosures = error.invalidDisclosures
+            assertEquals(1, invalidDisclosures.size)
+            assertEquals("Disclosed claim cannot be one of: _sd, ...", invalidDisclosures.keys.first())
+        }
+
+        // _sd
+        test("WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsIl9zZCIsIk3DtmJpdXMiXQ")
+
+        // ...
+        test("WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsIi4uLiIsIk3DtmJpdXMiXQ")
     }
 
     private suspend fun SdJwtVerifier<JwtAndClaims>.verifyExpectingError(

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/SdJwtVerifierTest.kt
@@ -56,7 +56,7 @@ class SdJwtVerifierTest {
             val error = assertIs<VerificationError.InvalidDisclosures>(exception.reason)
             val invalidDisclosures = error.invalidDisclosures
             assertEquals(1, invalidDisclosures.size)
-            assertEquals("Disclosed claim cannot be one of: _sd, ...", invalidDisclosures.keys.first())
+            assertEquals("Given claim should not contain an attribute named _sd_alg, or _sd, or ...", invalidDisclosures.keys.first())
         }
 
         // _sd

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -56,6 +56,7 @@ import javax.security.auth.x500.X500Principal
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
@@ -307,5 +308,29 @@ class SdJwtVcVerifierTest {
 
         val serialized = with(NimbusSdJwtOps) { sdJwt.serialize() }
         verifier.verify(serialized).getOrThrow()
+    }
+
+    @Test
+    fun `SdJwtVcVerifier must fail when an SD-JWT-VC contains a Disclosure using a reserved name`() = runTest {
+        val unverifiedSdJwt = SampleIssuer.issueUsingKid(kid = SampleIssuer.KEY_ID)
+        val verifier = DefaultSdJwtOps.SdJwtVcVerifier(
+            IssuerVerificationMethod.usingIssuerMetadata(HttpMock.clientReturning(SampleIssuer.issuerMeta)),
+            TypeMetadataPolicy.NotUsed,
+            null,
+        )
+
+        suspend fun test(disclosure: String) {
+            val exception = assertFailsWith<SdJwtVerificationException> { verifier.verify("$unverifiedSdJwt~$disclosure~").getOrThrow() }
+            val error = assertIs<VerificationError.InvalidDisclosures>(exception.reason)
+            val invalidDisclosures = error.invalidDisclosures
+            assertEquals(1, invalidDisclosures.size)
+            assertEquals("Disclosed claim cannot be one of: _sd, ...", invalidDisclosures.keys.first())
+        }
+
+        // _sd
+        test("WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsIl9zZCIsIk3DtmJpdXMiXQ")
+
+        // ...
+        test("WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsIi4uLiIsIk3DtmJpdXMiXQ")
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -324,7 +324,7 @@ class SdJwtVcVerifierTest {
             val error = assertIs<VerificationError.InvalidDisclosures>(exception.reason)
             val invalidDisclosures = error.invalidDisclosures
             assertEquals(1, invalidDisclosures.size)
-            assertEquals("Disclosed claim cannot be one of: _sd, ...", invalidDisclosures.keys.first())
+            assertEquals("Given claim should not contain an attribute named _sd_alg, or _sd, or ...", invalidDisclosures.keys.first())
         }
 
         // _sd


### PR DESCRIPTION
This PR adds a missing check in `Disclosure.decode()` that ensures that `ObjectProperties` do not use reserved claim names per [RFC9901](https://www.rfc-editor.org/rfc/rfc9901#section-7.1).

Tests have been added to verify the behavior of:
- `SdJwtVerifier`
- `SdJwtVcVerifier`
- `UnverifiedIssuanceFrom`

which are the entry points that accept unvalidated client input.

Fixes #473 