### PR TITLE
Drop support for DID/DIDUrl resolution

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/NimbusSdJwtVcVerifierFactory.kt
@@ -71,10 +71,6 @@ internal object NimbusSdJwtVcVerifierFactory : SdJwtVcVerifierFactory<NimbusSign
                     sdJwtVcSignatureVerifier(trust = issuerVerificationMethod.x509CertificateTrust)
                 }
 
-                is IssuerVerificationMethod.UsingDID -> {
-                    sdJwtVcSignatureVerifier(lookup = issuerVerificationMethod.didLookup)
-                }
-
                 is IssuerVerificationMethod.UsingX5cOrIssuerMetadata -> {
                     sdJwtVcSignatureVerifier(
                         httpClient = issuerVerificationMethod.httpClient,
@@ -138,22 +134,18 @@ private class NimbusSdJwtVcVerifier(
  * if it is trusted & it contains a SAN DNS equal to `iss` FQDN
  * - If `iss` claim is an HTTPS URI and there is a `x5c` claim key will be extracted from the leaf certificate,
  *  if it is trusted & it contains a SAN URI equal to `iss`
- * - If `iss` claim is a DID the key will be extracted by resolving it.
  *
  *  In addition, the verifier will ensure that `typ` claim is equal to dc+sd-jwt
  *
  * @param httpClient an http client, used while interacting with issuer
  * @param trust a function that accepts a chain of certificates (contents of `x5c` claim) and
  * indicates whether is trusted or not. If it is not provided, defaults to [X509CertificateTrust.None]
- * @param lookup an optional way of looking up public keys from DID Documents. A `null` value indicates
- * that holder doesn't support DIDs
  *
  * @return a SD-JWT-VC specific signature verifier as described above
  */
 internal fun sdJwtVcSignatureVerifier(
     httpClient: HttpClient? = null,
     trust: X509CertificateTrust<List<X509Certificate>>? = null,
-    lookup: LookupPublicKeysFromDIDDocument<NimbusJWK>? = null,
 ): JwtSignatureVerifier<NimbusSignedJWT> =
     JwtSignatureVerifier { unverifiedJwt ->
         withContext(Dispatchers.IO) {
@@ -164,7 +156,7 @@ internal fun sdJwtVcSignatureVerifier(
                     throw VerificationError.ParsingError.asException()
                 }
 
-            val (jwkSource, useKeyId) = issuerJwkSource(httpClient, trust, lookup, signedJwt)
+            val (jwkSource, useKeyId) = issuerJwkSource(httpClient, trust, signedJwt)
             yield()
 
             try {
@@ -181,7 +173,6 @@ internal fun sdJwtVcSignatureVerifier(
 private suspend fun issuerJwkSource(
     httpClient: HttpClient?,
     trust: X509CertificateTrust<List<X509Certificate>>?,
-    lookup: LookupPublicKeysFromDIDDocument<NimbusJWK>?,
     signedJwt: NimbusSignedJWT,
 ): IssuerJwkSource {
     suspend fun fromMetadata(source: Metadata): IssuerJwkSource {
@@ -208,21 +199,9 @@ private suspend fun issuerJwkSource(
         return IssuerJwkSource(NimbusImmutableJWKSet(NimbusJWKSet(mutableListOf(jwk))), false)
     }
 
-    suspend fun fromDid(source: DIDUrl): IssuerJwkSource {
-        if (null == lookup) raise(UnsupportedVerificationMethod("did"))
-        val jwks =
-            runCatchingCancellable {
-                lookup.lookup(source.iss, source.kid)?.let(::NimbusJWKSet)
-            }.getOrElse { raise(DIDLookupFailure("Failed to resolve $source", it)) }
-        if (null == jwks) raise(DIDLookupFailure("Failed to resolve $source"))
-
-        return IssuerJwkSource(NimbusImmutableJWKSet(jwks), false)
-    }
-
     return when (val source = keySource(signedJwt)) {
         is Metadata -> fromMetadata(source)
         is X509CertChain -> fromX509CertChain(source)
-        is DIDUrl -> fromDid(source)
     }
 }
 
@@ -244,15 +223,9 @@ internal sealed interface SdJwtVcIssuerPublicKeySource {
     data class X509CertChain(
         val chain: List<X509Certificate>,
     ) : SdJwtVcIssuerPublicKeySource
-
-    data class DIDUrl(
-        val iss: String,
-        val kid: String?,
-    ) : SdJwtVcIssuerPublicKeySource
 }
 
 private const val HTTPS_URI_SCHEME = "https"
-private const val DID_URI_SCHEME = "did"
 
 internal fun keySource(jwt: NimbusSignedJWT): SdJwtVcIssuerPublicKeySource {
     val kid = jwt.header?.keyID
@@ -268,7 +241,6 @@ internal fun keySource(jwt: NimbusSignedJWT): SdJwtVcIssuerPublicKeySource {
     return when {
         certChain.isNotEmpty() -> X509CertChain(certChain)
         issScheme == HTTPS_URI_SCHEME -> Metadata(issUrl, kid)
-        issScheme == DID_URI_SCHEME -> DIDUrl(iss, kid)
         else -> raise(CannotDetermineIssuerVerificationMethod)
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifier.kt
@@ -112,7 +112,7 @@ sealed interface SdJwtVcVerificationError {
         /**
          * Indicates the key verification methods is not supported.
          *
-         * @property method one of 'issuer-metadata', 'x5c', or 'did'
+         * @property method one of 'issuer-metadata', or 'x5c'
          */
         data class UnsupportedVerificationMethod(
             val method: String,
@@ -130,14 +130,6 @@ sealed interface SdJwtVcVerificationError {
          */
         data class UntrustedIssuerCertificate(
             val reason: String? = null,
-        ) : IssuerKeyVerificationError
-
-        /**
-         * DID resolution failed.
-         */
-        data class DIDLookupFailure(
-            val message: String,
-            val cause: Throwable? = null,
         ) : IssuerKeyVerificationError
 
         /**

--- a/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierFactory.kt
@@ -43,34 +43,6 @@ fun interface X509CertificateTrust<in X509Chain> {
 }
 
 /**
- * Deprecated in SD-JWT-VC draft 11 to be removed in future version
- * A function to look up public keys from DIDs/DID URLs.
- */
-@Deprecated(
-    message = "Deprecated in SD-JWT-VC draft 11 to be removed in future version",
-    level = DeprecationLevel.WARNING,
-)
-fun interface LookupPublicKeysFromDIDDocument<out JWK> {
-
-    /**
-     * Lookup the public keys from a DID document.
-     *
-     * @param did the identifier of the DID document
-     * @param didUrl optional DID URL, that is either absolute or relative to [did], indicating the exact public key
-     * to lookup from the DID document
-     *
-     * @return the matching public keys or null in case lookup fails for any reason
-     */
-    suspend fun lookup(
-        did: String,
-        didUrl: String?,
-    ): List<JWK>?
-
-    fun <JWK1> map(convert: (JWK) -> JWK1): LookupPublicKeysFromDIDDocument<JWK1> =
-        LookupPublicKeysFromDIDDocument { did, didUrl -> lookup(did, didUrl)?.map(convert) }
-}
-
-/**
  * How the Issuer of the Issuer-signed JWT of an SD-JWT VC will be verified.
  */
 sealed interface IssuerVerificationMethod<out JWT, out JWK, in X509Chain> {
@@ -88,17 +60,6 @@ sealed interface IssuerVerificationMethod<out JWT, out JWK, in X509Chain> {
     data class UsingX5c<X509Chain>(
         val x509CertificateTrust: X509CertificateTrust<X509Chain>,
     ) : IssuerVerificationMethod<Nothing, Nothing, X509Chain>
-
-    /**
-     * Using DID resolution
-     */
-    @Deprecated(
-        message = "Deprecated in SD-JWT-VC draft 11 to be removed in future version",
-        level = DeprecationLevel.WARNING,
-    )
-    data class UsingDID<JWK>(
-        val didLookup: LookupPublicKeysFromDIDDocument<JWK>,
-    ) : IssuerVerificationMethod<Nothing, JWK, Any?>
 
     /**
      * Using X509 Certificate trust or SD-JWT VC Issuer Metadata
@@ -123,7 +84,6 @@ sealed interface IssuerVerificationMethod<out JWT, out JWK, in X509Chain> {
         when (this) {
             is UsingIssuerMetadata -> UsingIssuerMetadata(httpClient)
             is UsingX5c -> UsingX5c(x509CertificateTrust.contraMap(convertFromX509Chain))
-            is UsingDID -> UsingDID(didLookup.map(convertToJwk))
             is UsingX5cOrIssuerMetadata -> UsingX5cOrIssuerMetadata(x509CertificateTrust.contraMap(convertFromX509Chain), httpClient)
             is Custom -> Custom(jwtSignatureVerifier.map(convertToJwt))
         }
@@ -133,9 +93,6 @@ sealed interface IssuerVerificationMethod<out JWT, out JWK, in X509Chain> {
 
         fun <X509Chain> usingX5c(x509CertificateTrust: X509CertificateTrust<X509Chain>): UsingX5c<X509Chain> =
             UsingX5c(x509CertificateTrust)
-
-        @Deprecated("Deprecated in SD-JWT-VC draft 11 to be removed in future version", level = DeprecationLevel.WARNING)
-        fun <JWK> usingDID(didLookup: LookupPublicKeysFromDIDDocument<JWK>): UsingDID<JWK> = UsingDID(didLookup)
 
         fun <X509Chain> usingX5cOrIssuerMetadata(
             x509CertificateTrust: X509CertificateTrust<X509Chain>,

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/KeyBindingTest.kt
@@ -223,9 +223,7 @@ class IssuerActor(
 
     private val signAlgorithm = JWSAlgorithm.ES256
     private val jwtType = JOSEObjectType(SdJwtVcSpec.MEDIA_SUBTYPE_DC_SD_JWT)
-    private val iss: String by lazy {
-        "did:jwk:${Base64UrlNoPadding.encode(issuerKey.toPublicJWK().toJSONString().encodeToByteArray())}"
-    }
+    private val iss: String = "https://issuer.example.com"
     private val expirationPeriod = (12 * 31).days
 
     /**

--- a/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/sdjwt/vc/SdJwtVcVerifierTest.kt
@@ -139,39 +139,6 @@ class SdJwtVcVerifierTest {
     }
 
     @Test
-    fun `keySource should return a DIDUrl when iss is a DID and kid is provided`() {
-        val expectedSource =
-            SdJwtVcIssuerPublicKeySource.DIDUrl(
-                iss = "did:ebsi:zkC6cUFUs3FiRp2xedNwih2",
-                kid = "did:ebsi:zkC6cUFUs3FiRp2xedNwih2#x8x4WxXHoPW7ccEO0zACL_miBfO-V7X_jofc-UEGzw4",
-            )
-        testForDid(expectedSource)
-    }
-
-    private fun testForDid(expectedSource: SdJwtVcIssuerPublicKeySource.DIDUrl) {
-        val jwt =
-            run {
-                val header =
-                    JWSHeader
-                        .Builder(JWSAlgorithm.ES256)
-                        .apply {
-                            type(JOSEObjectType(SdJwtVcSpec.MEDIA_SUBTYPE_DC_SD_JWT))
-                            expectedSource.kid?.let { keyID(it) }
-                        }.build()
-                val payload =
-                    JWTClaimsSet
-                        .Builder()
-                        .apply {
-                            issuer(expectedSource.iss)
-                        }.build()
-                SignedJWT(header, payload)
-            }
-
-        val actualSource = keySource(jwt)
-        assertEquals(expectedSource, actualSource)
-    }
-
-    @Test
     fun `SdJwtVcVerifier should verify an SD-JWT-VC when iss is HTTPS url using kid`() =
         runTest {
             val unverifiedSdJwt = SampleIssuer.issueUsingKid(kid = SampleIssuer.KEY_ID)


### PR DESCRIPTION
This PR drops DID/DIDUrl resolution support.

This Issuer verification method has been removed since SD-JWT-VC draft 11.
Users who require DID/DIDUrl support must migrate to `IssuerVerificationMethod.Custom`.